### PR TITLE
Add initial `ribose` CLI executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,33 @@
-# Ribose::Cli
+# Ribose CLI
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/ribose/cli`. To experiment with that code, run `bin/console` for an interactive prompt.
+[![Build
+Status](https://travis-ci.org/riboseinc/ribose-cli.svg?branch=master)](https://travis-ci.org/riboseinc/ribose-cli)
+[![Code
+Climate](https://codeclimate.com/github/riboseinc/ribose-cli/badges/gpa.svg)](https://codeclimate.com/github/riboseinc/ribose-cli)
 
-TODO: Delete this and the text above, and describe your gem
+The command line interface to the Ribose API.
 
 ## Installation
 
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'ribose-cli'
+gem "ribose-cli"
 ```
 
 And then execute:
 
-    $ bundle
+```sh
+$ bundle install
+```
 
 Or install it yourself as:
 
-    $ gem install ribose-cli
+```sh
+$ gem install ribose-cli
+```
 
 ## Usage
-
-TODO: Write usage instructions here
 
 ## Development
 

--- a/bin/ribose
+++ b/bin/ribose
@@ -1,0 +1,21 @@
+#!/usr/bin/env ruby
+# encoding: UTF-8
+
+# resolve bin path, ignoring symlinks
+require "pathname"
+bin_file = Pathname.new(__FILE__).realpath
+
+# add self to libpath
+$:.unshift File.expand_path("../../lib", bin_file)
+
+# Fixes https://github.com/rubygems/rubygems/issues/1420
+require "rubygems/specification"
+
+class Gem::Specification
+  def this; self; end
+end
+
+# start up the CLI
+require "ribose/cli"
+
+Ribose::CLI.start(ARGV)

--- a/lib/ribose/cli.rb
+++ b/lib/ribose/cli.rb
@@ -1,7 +1,12 @@
+require "thor"
+
 require "ribose/cli/version"
+require "ribose/cli/command"
 
 module Ribose
-  module Cli
-    # Your code goes here...
+  module CLI
+    def self.start(arguments)
+      Ribose::CLI::Command.start(arguments)
+    end
   end
 end

--- a/lib/ribose/cli/command.rb
+++ b/lib/ribose/cli/command.rb
@@ -1,0 +1,10 @@
+module Ribose
+  module CLI
+    class Command < Thor
+      desc "version", "The current active version"
+      def version
+        Thor::Shell::Basic.new.say(Ribose::CLI::VERSION)
+      end
+    end
+  end
+end

--- a/lib/ribose/cli/version.rb
+++ b/lib/ribose/cli/version.rb
@@ -1,5 +1,5 @@
 module Ribose
-  module Cli
+  module CLI
     VERSION = "0.1.0".freeze
   end
 end

--- a/ribose-cli.gemspec
+++ b/ribose-cli.gemspec
@@ -6,7 +6,7 @@ require "ribose/cli/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "ribose-cli"
-  spec.version       = Ribose::Cli::VERSION
+  spec.version       = Ribose::CLI::VERSION
   spec.authors       = ["Ribose Inc."]
   spec.email         = ["operations@ribose.com"]
 
@@ -20,6 +20,9 @@ Gem::Specification.new do |spec|
 
   spec.require_paths = ["lib"]
   spec.bindir        = "bin"
+  spec.executables   = "ribose"
+
+  spec.add_dependency "thor", "~> 0.19.4"
 
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/spec/ribose/cli_spec.rb
+++ b/spec/ribose/cli_spec.rb
@@ -1,4 +1,0 @@
-require "spec_helper"
-
-RSpec.describe Ribose::Cli do
-end


### PR DESCRIPTION
This commit adds the initial setup for the Ribose CLI. It usages the `bin/ribose` as a main gateway, and on the underneath it is using the `thor` gem to prepare it help documentation.

This commit also adds the `version` interface to the CLI, so now we can use `bin/ribose version` to retrieve the current version

```sh
bin/ribose version
```