### PR TITLE
Add CLI command to list user spaces

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in ribose-cli.gemspec
 gemspec
+gem "ribose", github: "riboseinc/ribose-ruby", ref: "156ac6f"

--- a/README.md
+++ b/README.md
@@ -29,6 +29,32 @@ $ gem install ribose-cli
 
 ## Usage
 
+To start with, we kept it pretty simple, clone this repo and then configure the
+following environment variables to get everything working.
+
+```sh
+export RIBOSE_API_TOKEN=YOUR_SECRET_API_TOKEN
+export RIBOSE_USER_EMAIL=YOUR_EMAIL_FOR_RIBOSE
+```
+
+### Spaces
+
+The `space` command retrieve space related resources, please use the `help`
+command to see what's sub-commands are available.
+
+```sh
+ribose help space
+```
+
+#### Listing spaces
+
+To list out the spaces, please use the `list` command, by default it will print
+out the basic information in tabular format.
+
+```sh
+ribose space list
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this gem, you can read the

--- a/bin/ribose
+++ b/bin/ribose
@@ -16,6 +16,7 @@ class Gem::Specification
 end
 
 # start up the CLI
+require "bundler/setup"
 require "ribose/cli"
 
 Ribose::CLI.start(ARGV)

--- a/lib/ribose/cli.rb
+++ b/lib/ribose/cli.rb
@@ -1,5 +1,8 @@
 require "thor"
+require "ribose"
 
+require "ribose/cli/auth"
+require "ribose/cli/util"
 require "ribose/cli/version"
 require "ribose/cli/command"
 

--- a/lib/ribose/cli/auth.rb
+++ b/lib/ribose/cli/auth.rb
@@ -1,0 +1,8 @@
+require "ribose"
+
+unless Ribose.configuration.api_token
+  Ribose.configure do |config|
+    config.api_token = ENV["RIBOSE_API_TOKEN"]
+    config.user_email = ENV["RIBOSE_USER_EMAIL"]
+  end
+end

--- a/lib/ribose/cli/command.rb
+++ b/lib/ribose/cli/command.rb
@@ -1,10 +1,15 @@
+require "ribose/cli/commands/space"
+
 module Ribose
   module CLI
     class Command < Thor
       desc "version", "The current active version"
       def version
-        Thor::Shell::Basic.new.say(Ribose::CLI::VERSION)
+        say(Ribose::CLI::VERSION)
       end
+
+      desc "space", "List, Add or Remove User Space"
+      subcommand :space, Ribose::CLI::Commands::Space
     end
   end
 end

--- a/lib/ribose/cli/commands/space.rb
+++ b/lib/ribose/cli/commands/space.rb
@@ -1,0 +1,28 @@
+module Ribose
+  module CLI
+    module Commands
+      class Space < Thor
+        desc "list", "List user spaces"
+        def list
+          say(table_view(list_user_spaces))
+        end
+
+        private
+
+        def list_user_spaces
+          @user_spaces ||= Ribose::Space.all
+        end
+
+        def table_rows(spaces)
+          spaces.map { |space| [space.id, space.name, space.active ] }
+        end
+
+        def table_view(spaces)
+          Ribose::CLI::Util.list(
+            headings: ["ID", "Name", "Active?"], rows: table_rows(spaces),
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/ribose/cli/util.rb
+++ b/lib/ribose/cli/util.rb
@@ -1,0 +1,15 @@
+require "terminal-table"
+
+module Ribose
+  module CLI
+    module Util
+      def self.list(headings:, rows:, table_wdith: 80)
+        Terminal::Table.new do |table|
+          table.headings = headings
+          table.style = { width: table_wdith }
+          table.rows = rows
+        end
+      end
+    end
+  end
+end

--- a/ribose-cli.gemspec
+++ b/ribose-cli.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.executables   = "ribose"
 
   spec.add_dependency "thor", "~> 0.19.4"
+  spec.add_dependency "terminal-table"
 
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/spec/acceptance/space_spec.rb
+++ b/spec/acceptance/space_spec.rb
@@ -1,0 +1,18 @@
+require "spec_helper"
+
+RSpec.describe "Ribose Space" do
+  describe "Listing spaces" do
+    it "retrieves and list out user spaces" do
+      command = %w(space list)
+      stub_listing_ribose_spaces
+
+      Ribose::CLI.start(command)
+
+      expect(Ribose::Space).to have_received(:all)
+    end
+  end
+
+  def stub_listing_ribose_spaces
+    allow(Ribose::Space).to receive(:all).and_return([])
+  end
+end


### PR DESCRIPTION
Ribose conversations are organized based on spaces, and normally one user will be associated with one or more spaces. This interface adds the `space list` command, that we can use to retrieve user spaces.

```sh
ribose space list
```