### PR TITLE
Add support to list spaces in `json` format

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,4 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in ribose-cli.gemspec
 gemspec
-gem "ribose", github: "riboseinc/ribose-ruby", ref: "156ac6f"
+gem "ribose", github: "riboseinc/ribose-ruby", ref: "04f6585"

--- a/README.md
+++ b/README.md
@@ -55,6 +55,13 @@ out the basic information in tabular format.
 ribose space list
 ```
 
+This interface also has support `json` format, if we want the output to be in
+`json` then we can use the following
+
+```sh
+ribose space list --format json
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this gem, you can read the

--- a/lib/ribose/cli/commands/space.rb
+++ b/lib/ribose/cli/commands/space.rb
@@ -3,14 +3,25 @@ module Ribose
     module Commands
       class Space < Thor
         desc "list", "List user spaces"
+        option :format, aliases: "-f", desc: "Output format, eg: json"
         def list
-          say(table_view(list_user_spaces))
+          say(build_output(list_user_spaces, options))
         end
 
         private
 
         def list_user_spaces
           @user_spaces ||= Ribose::Space.all
+        end
+
+        def build_output(spaces, options)
+          json_view(spaces, options) || table_view(spaces)
+        end
+
+        def json_view(spaces, options)
+          if options[:format] == "json"
+            spaces.map(&:to_h).to_json
+          end
         end
 
         def table_rows(spaces)

--- a/ribose-cli.gemspec
+++ b/ribose-cli.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "webmock", "~> 2.0"
 end

--- a/spec/acceptance/space_spec.rb
+++ b/spec/acceptance/space_spec.rb
@@ -2,17 +2,28 @@ require "spec_helper"
 
 RSpec.describe "Ribose Space" do
   describe "Listing spaces" do
-    it "retrieves and list out user spaces" do
-      command = %w(space list)
-      stub_listing_ribose_spaces
+    context "default option" do
+      it "retrieves user spaces in default format" do
+        command = %w(space list)
 
-      Ribose::CLI.start(command)
+        stub_ribose_space_list_api
+        output = capture_stdout { Ribose::CLI.start(command) }
 
-      expect(Ribose::Space).to have_received(:all)
+        expect(output).to match(/Work/)
+        expect(output).to match(/123456789/)
+      end
     end
-  end
 
-  def stub_listing_ribose_spaces
-    allow(Ribose::Space).to receive(:all).and_return([])
+    context "with format option" do
+      it "retrieves user spaces in specified format" do
+        command = %w(space list --format json)
+
+        stub_ribose_space_list_api
+        output = capture_stdout { Ribose::CLI.start(command) }
+
+        expect(output).to match(/"name":"Work"/)
+        expect(output).to match(/"id":"123456789"/)
+      end
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,13 @@
-require "bundler/setup"
+require "webmock/rspec"
 require "ribose/cli"
+require "ribose/rspec"
+
+Dir["./spec/support/**/*.rb"].sort.each { |file| require file }
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"
+  config.include Ribose::ConsoleHelper
 
   config.expect_with :rspec do |c|
     c.syntax = :expect

--- a/spec/support/console_helper.rb
+++ b/spec/support/console_helper.rb
@@ -1,0 +1,29 @@
+module Ribose
+  module ConsoleHelper
+    def capture_stdout(&_block)
+      original_stdout = $stdout
+      $stdout = fake = StringIO.new
+
+      begin
+        yield
+      ensure
+        $stdout = original_stdout
+      end
+
+      fake.string
+    end
+
+    def capture_stderr(&_block)
+      original_stderr = $stderr
+      $stderr = fake = StringIO.new
+
+      begin
+        yield
+      ensure
+        $stderr = original_stderr
+      end
+
+      fake.string
+    end
+  end
+end


### PR DESCRIPTION
Currently, we are displaying the `space list` as table, which only contains `name` and id for the spaces, but in some cases we might need all the data in different format.

This commit adds `--format` option support to the `space list` interface, so we can easily format the output as necessary

```sh
ribose space list --format json
```