### PR TITLE
Remove width specific settings for table view

### DIFF
--- a/lib/ribose/cli/util.rb
+++ b/lib/ribose/cli/util.rb
@@ -3,10 +3,9 @@ require "terminal-table"
 module Ribose
   module CLI
     module Util
-      def self.list(headings:, rows:, table_wdith: 80)
+      def self.list(headings:, rows:)
         Terminal::Table.new do |table|
           table.headings = headings
-          table.style = { width: table_wdith }
           table.rows = rows
         end
       end


### PR DESCRIPTION
We are using the `terminal-table` gem to display the table view, but we were explicitly setting up the width for the table which was causing some issue when our content exceed that limit.

This commit fixes that issue and left the width settings to the gem default which should be the full width of the screen.

Fixes #10