### PR TITLE
Add interface to set Ribose configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,14 @@ $ gem install ribose-cli
 
 ## Usage
 
-To start with, we kept it pretty simple, clone this repo and then configure the
-following environment variables to get everything working.
+### Configure
+
+To start with, we kept it pretty simple, install this gem & then configure your
+API Token and email using the following interface, This will store your Ribose
+configuration as `.riboserc` in the home directory.
 
 ```sh
-export RIBOSE_API_TOKEN=YOUR_SECRET_API_TOKEN
-export RIBOSE_USER_EMAIL=YOUR_EMAIL_FOR_RIBOSE
+ribose config --token="YOUR_API_TOKEN" --email="youremail@example.com"
 ```
 
 ### Spaces

--- a/lib/ribose/cli/command.rb
+++ b/lib/ribose/cli/command.rb
@@ -1,15 +1,26 @@
+require "ribose/cli/rcfile"
 require "ribose/cli/commands/space"
 
 module Ribose
   module CLI
     class Command < Thor
+      desc "space", "List, Add or Remove User Space"
+      subcommand :space, Ribose::CLI::Commands::Space
+
+      desc "config", "Configure API Key and User Email"
+      option :token, required: true, desc: "Your API Token for Ribose"
+      option :email, required: true, desc: "Your email address for Ribose"
+
+      def config
+        Ribose::CLI::RCFile.set(
+          email: options[:email], token: options[:token],
+        )
+      end
+
       desc "version", "The current active version"
       def version
         say(Ribose::CLI::VERSION)
       end
-
-      desc "space", "List, Add or Remove User Space"
-      subcommand :space, Ribose::CLI::Commands::Space
     end
   end
 end

--- a/lib/ribose/cli/rcfile.rb
+++ b/lib/ribose/cli/rcfile.rb
@@ -1,0 +1,57 @@
+require "yaml"
+require "singleton"
+
+module Ribose
+  module CLI
+    class RCFile
+      attr_reader :path, :data
+      FILE_NAME = ".riboserc".freeze
+
+      def initialize
+        @path = build_rcfile_path
+        @data = load_configuration
+      end
+
+      def set(token:, email:)
+        data[:api_token] = token
+        data[:user_email] = email
+
+        write_api_details_to_file
+      end
+
+      def self.api_token
+        new.data[:api_token]
+      end
+
+      def self.user_email
+        new.data[:user_email]
+      end
+
+      def self.set(token:, email:)
+        new.set(token: token, email: email)
+      end
+
+      private
+
+      def build_rcfile_path
+        File.join(File.expand_path("~"), FILE_NAME)
+      end
+
+      def load_configuration
+        YAML.load_file(path)
+      rescue Errno::ENOENT
+        default_configuration
+      end
+
+      def default_configuration
+        { api_token: nil, user_email: nil }
+      end
+
+      def write_api_details_to_file
+        File.open(path, File::RDWR | File::TRUNC | File::CREAT, 0o0600) do |rc|
+          rc.write(data.to_yaml)
+        end
+      end
+    end
+  end
+end

--- a/spec/acceptance/config_spec.rb
+++ b/spec/acceptance/config_spec.rb
@@ -1,0 +1,17 @@
+require "spec_helper"
+
+RSpec.describe "Config" do
+  it "allows us to set token and user email" do
+    allow(File).to receive(:expand_path).and_return(fixtures_path)
+    command = %w(config --token SECRET_TOKEN --email user-one@ribose.com)
+
+    Ribose::CLI.start(command)
+
+    expect(Ribose::CLI::RCFile.api_token).to eq("SECRET_TOKEN")
+    expect(Ribose::CLI::RCFile.user_email).to eq("user-one@ribose.com")
+  end
+
+  def fixtures_path
+    File.expand_path("../../fixtures", __FILE__)
+  end
+end

--- a/spec/fixtures/.riboserc
+++ b/spec/fixtures/.riboserc
@@ -1,0 +1,3 @@
+---
+:api_token: SECRET_TOKEN
+:user_email: user-one@example.com

--- a/spec/ribose/cli/rcfile_spec.rb
+++ b/spec/ribose/cli/rcfile_spec.rb
@@ -1,0 +1,21 @@
+require "spec_helper"
+require "ribose/cli/rcfile"
+
+RSpec.describe Ribose::CLI::RCFile do
+  describe ".set" do
+    it "allows us to set API Token and User Email" do
+      api_token = "SECRET_TOKEN"
+      user_email = "user-one@example.com"
+      allow(File).to receive(:expand_path).and_return(fixtures_path)
+
+      Ribose::CLI::RCFile.set(token: api_token, email: user_email)
+
+      expect(Ribose::CLI::RCFile.api_token).to eq(api_token)
+      expect(Ribose::CLI::RCFile.user_email).to eq(user_email)
+    end
+  end
+
+  def fixtures_path
+    File.expand_path("../../../fixtures", __FILE__)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,4 +12,11 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
+
+  config.before :all do
+    Ribose.configure do |ribose_config|
+      ribose_config.api_token = ENV["RIBOSE_API_TOKEN"] || "SECRET_TOKEN"
+      ribose_config.user_email = ENV["RIBOSE_USER_EMAIL"] || "user@ribose.com"
+    end
+  end
 end


### PR DESCRIPTION
The `ribose-cli` gem requires us to set the valid Ribose config details and as of now we were using some environment variables. But now that we started to extend let's store those in a more sustainable storage.

Considering our scenario, this commit adopt the RCfile based storage for now and also allows us to set those through CLI. Once we a stable situation then we can also try to look into some alternatives. Usages:

```sh
ribose config --token=API_TOKEN --email="user@ribose.com"
```