### PR TITLE
Replace the old way of user authorization

### DIFF
--- a/lib/ribose/cli.rb
+++ b/lib/ribose/cli.rb
@@ -10,6 +10,12 @@ module Ribose
   module CLI
     def self.start(arguments)
       Ribose::CLI::Command.start(arguments)
+    rescue Ribose::Errors::Forbidden
+      Thor::Shell::Basic.new.say(
+        "Invalid: Missing API Configuration\n\n" \
+        "Ribose API Token & Email are required for any of the CLI operation\n" \
+        "You can set your API Key using `ribose config --token "" --email "" `",
+      )
     end
   end
 end

--- a/lib/ribose/cli/auth.rb
+++ b/lib/ribose/cli/auth.rb
@@ -1,8 +1,9 @@
 require "ribose"
+require "ribose/cli/rcfile"
 
 unless Ribose.configuration.api_token
   Ribose.configure do |config|
-    config.api_token = ENV["RIBOSE_API_TOKEN"]
-    config.user_email = ENV["RIBOSE_USER_EMAIL"]
+    config.api_token = Ribose::CLI::RCFile.api_token
+    config.user_email = Ribose::CLI::RCFile.user_email
   end
 end

--- a/spec/acceptance/config_spec.rb
+++ b/spec/acceptance/config_spec.rb
@@ -3,12 +3,12 @@ require "spec_helper"
 RSpec.describe "Config" do
   it "allows us to set token and user email" do
     allow(File).to receive(:expand_path).and_return(fixtures_path)
-    command = %w(config --token SECRET_TOKEN --email user-one@ribose.com)
+    command = %w(config --token SECRET_TOKEN --email user-one@example.com)
 
     Ribose::CLI.start(command)
 
     expect(Ribose::CLI::RCFile.api_token).to eq("SECRET_TOKEN")
-    expect(Ribose::CLI::RCFile.user_email).to eq("user-one@ribose.com")
+    expect(Ribose::CLI::RCFile.user_email).to eq("user-one@example.com")
   end
 
   def fixtures_path


### PR DESCRIPTION
In the last commit, we have moved to rcfile based configuration, but our CLI was still using the old environment variables based configuration. This commit replaces that with the recent updates and it also adds the error message for invalid configuration.