### PR TITLE
Add support to create a new user space

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,4 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in ribose-cli.gemspec
 gemspec
-gem "ribose", github: "riboseinc/ribose-ruby", ref: "04f6585"
+gem "ribose", github: "riboseinc/ribose-ruby", ref: "060952a"

--- a/README.md
+++ b/README.md
@@ -64,6 +64,15 @@ This interface also has support `json` format, if we want the output to be in
 ribose space list --format json
 ```
 
+#### Create a new space
+
+To create a new user space we can use the following interface
+
+```sh
+ribose space add --name "Space name" --access "open" --category-id 12 \
+  --description "Space description"
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this gem, you can read the

--- a/lib/ribose/cli/commands/space.rb
+++ b/lib/ribose/cli/commands/space.rb
@@ -4,14 +4,35 @@ module Ribose
       class Space < Thor
         desc "list", "List user spaces"
         option :format, aliases: "-f", desc: "Output format, eg: json"
+
         def list
           say(build_output(list_user_spaces, options))
+        end
+
+        desc "add", "Add a new user space"
+        option :access, desc: "The visiblity for the space"
+        option :name, aliases: "-n", desc: "Name of the space"
+        option :description, desc: "The description for space"
+        option :category_id, desc: "The category for this space"
+
+        def add
+          space = create_space(options)
+          say("New Space created! Id: " + space.id)
         end
 
         private
 
         def list_user_spaces
           @user_spaces ||= Ribose::Space.all
+        end
+
+        def create_space(attributes)
+          Ribose::Space.create(
+            name: attributes[:name],
+            access: attributes[:access] || "open",
+            description: attributes[:description],
+            category_id: attributes[:category_id],
+          )
         end
 
         def build_output(spaces, options)

--- a/spec/acceptance/space_spec.rb
+++ b/spec/acceptance/space_spec.rb
@@ -26,4 +26,31 @@ RSpec.describe "Ribose Space" do
       end
     end
   end
+
+  describe "Adding a new space" do
+    it "allows us to add a new space" do
+      command = %W(
+        space add
+        --name #{space.name}
+        --access #{space.access}
+        --description #{space.description}
+        --category-id #{space.category_id}
+      )
+
+      stub_ribose_space_create_api(space.to_h)
+      output = capture_stdout { Ribose::CLI.start(command) }
+
+      expect(output).to match(/New Space created!/)
+      expect(output).to match(/Id: 6b2741ad-4cde-4b4d-af3b-a162a4f6bc25/)
+    end
+  end
+
+  def space
+    @space ||= OpenStruct.new(
+      access: "public",
+      description: "Space description",
+      category_id: "12",
+      name: "CLI Space",
+    )
+  end
 end


### PR DESCRIPTION
Ribose discussions are organized by user spaces, and normally one user might be involved in one or multiple space and they also can create a new user space when necessary.

This commit adds support to create a new user space using the CLI and it usages the `Ribose Client` underneath to create a new user space.

```sh
ribose space add --name "Space name" --access "open" --category-id 12 --description "Space description"
```