### PR TITLE
Add support to remove an existing user space

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,4 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in ribose-cli.gemspec
 gemspec
-gem "ribose", github: "riboseinc/ribose-ruby", ref: "060952a"
+gem "ribose", github: "riboseinc/ribose-ruby", ref: "f1d040b"

--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ ribose space add --name "Space name" --access "open" --category-id 12 \
   --description "Space description"
 ```
 
+#### Remove an existing space
+
+```sh
+ribose space remove --space-id 123456789 --confirmation 123456789
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this gem, you can read the

--- a/lib/ribose/cli/commands/space.rb
+++ b/lib/ribose/cli/commands/space.rb
@@ -20,6 +20,17 @@ module Ribose
           say("New Space created! Id: " + space.id)
         end
 
+        desc "remove", "Remove an existing space"
+        option :space_id, required: true, desc: "The Space UUID"
+        option :confirmation, required: true, desc: "The confirmation"
+
+        def remove
+          remove_space(options)
+          say("The Sapce has been removed!")
+        rescue
+          say("Please provide a valid Space UUID")
+        end
+
         private
 
         def list_user_spaces
@@ -32,6 +43,13 @@ module Ribose
             access: attributes[:access] || "open",
             description: attributes[:description],
             category_id: attributes[:category_id],
+          )
+        end
+
+        def remove_space(attributes)
+          Ribose::Space.remove(
+            attributes[:space_id],
+            password_confirmation: attributes[:confirmation],
           )
         end
 

--- a/spec/acceptance/space_spec.rb
+++ b/spec/acceptance/space_spec.rb
@@ -45,6 +45,18 @@ RSpec.describe "Ribose Space" do
     end
   end
 
+  describe "Remove an existing space" do
+    it "removes an existing space" do
+      space_uuid = "6b2741ad-4cde-4b4d-af3b-a162a4f6bc25"
+      command = %W(space remove --space-id #{space_uuid} --confirmation 12345)
+
+      stub_ribose_space_remove_api(space_uuid, password_confirmation: "12345")
+      output = capture_stdout { Ribose::CLI.start(command) }
+
+      expect(output).to match(/The Sapce has been removed!/)
+    end
+  end
+
   def space
     @space ||= OpenStruct.new(
       access: "public",


### PR DESCRIPTION
This commit adds the interface to remove an existing user space and we can do so by providing valid details. Usages:

```sh
ribose space remove --space-id 12344567 --confirmation 12345
```