### PR TITLE
Add interface to list files for a Space

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,20 @@ ribose space add --name "Space name" --access "open" --category-id 12 \
 ribose space remove --space-id 123456789 --confirmation 123456789
 ```
 
+### Files
+
+#### Listing files
+
+Ribose space may contain multiple files, and if we want to retrieve the list of
+the files of any space then we can use to following interface.
+
+```sh
+ribose file list --space-id 123456
+```
+
+The above interface will retrieve the basic details in tabular format, but it
+also support additional `format` option, acceptable option: `json`.
+
 ## Development
 
 We are following Sandi Metz's Rules for this gem, you can read the

--- a/lib/ribose/cli/command.rb
+++ b/lib/ribose/cli/command.rb
@@ -1,11 +1,15 @@
 require "ribose/cli/rcfile"
 require "ribose/cli/commands/space"
+require "ribose/cli/commands/file"
 
 module Ribose
   module CLI
     class Command < Thor
       desc "space", "List, Add or Remove User Space"
       subcommand :space, Ribose::CLI::Commands::Space
+
+      desc "file", "List, Add or Remove Files"
+      subcommand :file, Ribose::CLI::Commands::File
 
       desc "config", "Configure API Key and User Email"
       option :token, required: true, desc: "Your API Token for Ribose"

--- a/lib/ribose/cli/commands/file.rb
+++ b/lib/ribose/cli/commands/file.rb
@@ -1,0 +1,41 @@
+module Ribose
+  module CLI
+    module Commands
+      class File < Thor
+        desc "list", "Listing the files for a space"
+        option :format, aliases: "-f", desc: "Output format, eg: json"
+        option :space_id, required: true, aliases: "-s", desc: "The Space UUID"
+
+        def list
+          say(build_output(list_files(options), options))
+        end
+
+        private
+
+        def list_files(attributes)
+          @files ||= Ribose::SpaceFile.all(attributes[:space_id])
+        end
+
+        def build_output(files, options)
+          json_view(files, options) || table_view(files)
+        end
+
+        def json_view(files, options)
+          if options[:format] == "json"
+            files.map(&:to_h).to_json
+          end
+        end
+
+        def table_rows(files)
+          files.map { |file| [file.id, file.name, file.version] }
+        end
+
+        def table_view(files)
+          Ribose::CLI::Util.list(
+            headings: ["ID", "Name", "Versions"], rows: table_rows(files),
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/acceptance/file_spec.rb
+++ b/spec/acceptance/file_spec.rb
@@ -1,0 +1,15 @@
+require "spec_helper"
+
+RSpec.describe "File Interface" do
+  describe "listing files" do
+    it "retrieves the list of files" do
+      command = %w(file list --space-id 123456 --format json)
+
+      stub_ribose_space_file_list(123456)
+      output = capture_stdout { Ribose::CLI.start(command) }
+
+      expect(output).to match(/"id":9896/)
+      expect(output).to match(/"name":"sample-file.png"/)
+    end
+  end
+end


### PR DESCRIPTION
In Riobse, the files are organized based on a user space, and this commit adds the interface to retrieve the list of files. By default this will return the basic details in tabular format.

But we also have an one additional option `--format` that allows us to specify the output format, current accepted option is `json`.

```sh
ribose file list --space-id 123456
```