### PR TITLE
List conversations for a user space

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,4 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in ribose-cli.gemspec
 gemspec
-gem "ribose", github: "riboseinc/ribose-ruby", ref: "f1d040b"
+gem "ribose", github: "riboseinc/ribose-ruby", ref: "e22159a"

--- a/README.md
+++ b/README.md
@@ -93,6 +93,14 @@ ribose file list --space-id 123456
 The above interface will retrieve the basic details in tabular format, but it
 also support additional `format` option, acceptable option: `json`.
 
+### Conversations
+
+#### Listing conversations
+
+```sh
+ribose conversation list --space-id 123456789
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this gem, you can read the

--- a/lib/ribose/cli/command.rb
+++ b/lib/ribose/cli/command.rb
@@ -1,6 +1,7 @@
 require "ribose/cli/rcfile"
 require "ribose/cli/commands/space"
 require "ribose/cli/commands/file"
+require "ribose/cli/commands/conversation"
 
 module Ribose
   module CLI
@@ -10,6 +11,9 @@ module Ribose
 
       desc "file", "List, Add or Remove Files"
       subcommand :file, Ribose::CLI::Commands::File
+
+      desc "conversation", "List, Add or Remove Conversation"
+      subcommand :conversation, Ribose::CLI::Commands::Conversation
 
       desc "config", "Configure API Key and User Email"
       option :token, required: true, desc: "Your API Token for Ribose"

--- a/lib/ribose/cli/commands/conversation.rb
+++ b/lib/ribose/cli/commands/conversation.rb
@@ -1,0 +1,41 @@
+module Ribose
+  module CLI
+    module Commands
+      class Conversation < Thor
+        desc "list", "Listing A Space Conversations"
+        option :format, aliases: "-f", desc: "Output format, eg: json"
+        option :space_id, required: true, aliases: "-s", desc: "The Space UUID"
+
+        def list
+          say(build_output(list_conversations, options))
+        end
+
+        private
+
+        def list_conversations
+          @conversations ||= Ribose::Conversation.all(options[:space_id])
+        end
+
+        def build_output(conversations, options)
+          json_view(conversations, options) || table_view(conversations)
+        end
+
+        def json_view(conversations, options)
+          if options[:format] == "json"
+            conversations.map(&:to_h).to_json
+          end
+        end
+
+        def table_rows(conversations)
+          conversations.map { |conv| [conv.id, conv.name] }
+        end
+
+        def table_view(conversations)
+          Ribose::CLI::Util.list(
+            headings: ["ID", "Title"], rows: table_rows(conversations),
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/acceptance/conversation_spec.rb
+++ b/spec/acceptance/conversation_spec.rb
@@ -1,0 +1,15 @@
+require "spec_helper"
+
+RSpec.describe "Space Conversation" do
+  describe "Listing conversations" do
+    it "retrieves the list of conversations" do
+      command = %w(conversation list --space-id 123456789 --format json)
+
+      stub_ribose_space_conversation_list(123456789)
+      output = capture_stdout { Ribose::CLI.start(command) }
+
+      expect(output).to match(/"name":"Sample conversation"/)
+      expect(output).to match(/"id":"741ebd0f-0959-42c5-b7d3-7749666d2f5f"/)
+    end
+  end
+end


### PR DESCRIPTION
In Ribose Space, discussions are happens as conversations. User can create new conversation or participate to an existing space conversation.

This commit adds the interface to list  existing conversation as tabular data, and as usual this interface also supports `format` option to return the output in different format.

```sh
ribose conversation list --space-id space_uuid
```