### PR TITLE
Add an interface to create a new conversation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,4 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in ribose-cli.gemspec
 gemspec
-gem "ribose", github: "riboseinc/ribose-ruby", ref: "e22159a"
+gem "ribose", github: "riboseinc/ribose-ruby", ref: "4ffb832"

--- a/README.md
+++ b/README.md
@@ -101,6 +101,13 @@ also support additional `format` option, acceptable option: `json`.
 ribose conversation list --space-id 123456789
 ```
 
+#### Create A New Conversation
+
+```sh
+ribose conversation add --space-id 123456789 --title "Conversation Title" \
+  --tags "sample, conversation"
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this gem, you can read the

--- a/lib/ribose/cli/commands/conversation.rb
+++ b/lib/ribose/cli/commands/conversation.rb
@@ -10,10 +10,26 @@ module Ribose
           say(build_output(list_conversations, options))
         end
 
+        desc "add", "Add a new conversation to Space"
+        option :space_id, required: true, aliases: "-s", desc: "The Space UUID"
+        option :title, required: true, desc: "The title for the conversation"
+        option :tags, aliases: "-t", desc: "The tags for the conversation"
+
+        def add
+          conversation = create_conversation(options)
+          say("New Conversation created! Id: " + conversation.id)
+        end
+
         private
 
         def list_conversations
           @conversations ||= Ribose::Conversation.all(options[:space_id])
+        end
+
+        def create_conversation(options)
+          Ribose::Conversation.create(
+            options[:space_id], name: options[:title], tag_list: options[:tags]
+          )
         end
 
         def build_output(conversations, options)

--- a/spec/acceptance/conversation_spec.rb
+++ b/spec/acceptance/conversation_spec.rb
@@ -12,4 +12,36 @@ RSpec.describe "Space Conversation" do
       expect(output).to match(/"id":"741ebd0f-0959-42c5-b7d3-7749666d2f5f"/)
     end
   end
+
+  describe "Adding a new conversations" do
+    it "creates a new conversation into a user space" do
+      command = %W(
+        conversation add
+        --title #{conversation.title}
+        --space-id #{conversation.space_id}
+        --tags #{conversation.tags}
+      )
+
+      stub__conversation_creation(conversation)
+      output = capture_stdout { Ribose::CLI.start(command) }
+
+      expect(output).to match(/New Conversation created!/)
+      expect(output).to match(/Id: ee50bb3c-ed79-4efc-821a-64926f645bfb/)
+    end
+  end
+
+  def conversation
+    @conversation ||= OpenStruct.new(
+      space_id: 123_456_789, title: "The Special Conversation", tags: "sample",
+    )
+  end
+
+  def stub__conversation_creation(conversation)
+    stub_ribose_space_conversation_create(
+      conversation.space_id,
+      name: conversation.title,
+      tag_list: conversation.tags,
+      space_id: conversation.space_id.to_s,
+    )
+  end
 end


### PR DESCRIPTION
Ribose API supports the creation of new conversation under any space, This commit adds the CLI interface for this endpoint and it also simplifies some internal details. Usage:

```sh
ribose conversation add \
  --space-id 123_456_789 \
  --title "The Conversation Title" \
  --tags "Conversation tags separated by comma"
```