### PR TITLE
Add support to remove a space conversation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,4 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in ribose-cli.gemspec
 gemspec
-gem "ribose", github: "riboseinc/ribose-ruby", ref: "4ffb832"
+gem "ribose", github: "riboseinc/ribose-ruby", ref: "ae6e223"

--- a/README.md
+++ b/README.md
@@ -108,6 +108,12 @@ ribose conversation add --space-id 123456789 --title "Conversation Title" \
   --tags "sample, conversation"
 ```
 
+#### Remove A Conversation
+
+```sh
+ribose conversation remove --space-id 1234 --conversation-id 5678
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this gem, you can read the

--- a/lib/ribose/cli/commands/conversation.rb
+++ b/lib/ribose/cli/commands/conversation.rb
@@ -20,6 +20,17 @@ module Ribose
           say("New Conversation created! Id: " + conversation.id)
         end
 
+        desc "remove", "Remove A Conversation from Space"
+        option :space_id, required: true, aliases: "-s", desc: "The Space UUID"
+        option :conversation_id, required: true, aliases: "-c"
+
+        def remove
+          remove_conversation(options)
+          say("The Conversation has been removed!")
+        rescue
+          say("Please provide a valid Conversation UUID")
+        end
+
         private
 
         def list_conversations
@@ -29,6 +40,13 @@ module Ribose
         def create_conversation(options)
           Ribose::Conversation.create(
             options[:space_id], name: options[:title], tag_list: options[:tags]
+          )
+        end
+
+        def remove_conversation(options)
+          Ribose::Conversation.remove(
+            space_id: options[:space_id],
+            conversation_id: options[:conversation_id],
           )
         end
 

--- a/spec/acceptance/conversation_spec.rb
+++ b/spec/acceptance/conversation_spec.rb
@@ -30,6 +30,17 @@ RSpec.describe "Space Conversation" do
     end
   end
 
+  describe "Remove a conversation" do
+    it "removes a conversation from a speace" do
+      command = %w(conversation remove -s 9876 --conversation-id 12345)
+
+      stub_ribose_space_conversation_remove(9876, 12345)
+      output = capture_stdout { Ribose::CLI.start(command) }
+
+      expect(output).to match(/The Conversation has been removed!/)
+    end
+  end
+
   def conversation
     @conversation ||= OpenStruct.new(
       space_id: 123_456_789, title: "The Special Conversation", tags: "sample",


### PR DESCRIPTION
Ribose API client offers an interface to remove a conversation form a user space. This commit adds support for that interface through the CLI. Usages:

```sh
ribose conversation remove --space-id 1234 --conversation-id 56789
```