### PR TITLE
Add support to list conversation messages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,4 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in ribose-cli.gemspec
 gemspec
-gem "ribose", github: "riboseinc/ribose-ruby", ref: "ae6e223"
+gem "ribose", github: "riboseinc/ribose-ruby", ref: "6c272f9"

--- a/README.md
+++ b/README.md
@@ -114,6 +114,14 @@ ribose conversation add --space-id 123456789 --title "Conversation Title" \
 ribose conversation remove --space-id 1234 --conversation-id 5678
 ```
 
+### Message
+
+#### Listing conversation messages
+
+```sh
+ribose message list --space-id 12345 --conversation-id 56789
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this gem, you can read the

--- a/lib/ribose/cli.rb
+++ b/lib/ribose/cli.rb
@@ -18,4 +18,9 @@ module Ribose
       )
     end
   end
+
+  # Temporary: The API Client will implement it
+  module Errors
+    class Forbidden < StandardError; end
+  end
 end

--- a/lib/ribose/cli/command.rb
+++ b/lib/ribose/cli/command.rb
@@ -2,6 +2,7 @@ require "ribose/cli/rcfile"
 require "ribose/cli/commands/space"
 require "ribose/cli/commands/file"
 require "ribose/cli/commands/conversation"
+require "ribose/cli/commands/message"
 
 module Ribose
   module CLI
@@ -14,6 +15,9 @@ module Ribose
 
       desc "conversation", "List, Add or Remove Conversation"
       subcommand :conversation, Ribose::CLI::Commands::Conversation
+
+      desc "message", "List, Add or Remove Message"
+      subcommand :message, Ribose::CLI::Commands::Message
 
       desc "config", "Configure API Key and User Email"
       option :token, required: true, desc: "Your API Token for Ribose"

--- a/lib/ribose/cli/commands/message.rb
+++ b/lib/ribose/cli/commands/message.rb
@@ -1,0 +1,52 @@
+module Ribose
+  module CLI
+    module Commands
+      class Message < Thor
+        desc "list", "Listing Messages"
+        option :conversation_id, aliases: "-c", required: true
+        option :format, aliases: "-f", desc: "Output format, eg: json"
+        option :space_id, required: true, aliases: "-s", desc: "The Space UUID"
+
+        def list
+          say(build_output(list_messages, options))
+        end
+
+        private
+
+        def list_messages
+          @messages ||= Ribose::Message.all(
+            space_id: options[:space_id],
+            conversation_id: options[:conversation_id],
+          )
+        end
+
+        def build_output(messages, options)
+          json_view(messages, options) || table_view(messages)
+        end
+
+        def json_view(messages, options)
+          if options[:format] == "json"
+            messages.map(&:to_h).to_json
+          end
+        end
+
+        def table_rows(messages)
+          messages.map do |message|
+            [message.id, message.user.name, sanitize(message.contents)]
+          end
+        end
+
+        def sanitize(content, length = 30)
+          content = content.to_s.gsub(/<\/?[^>]*>/, "")
+          Ribose::CLI::Util.truncate(content, length)
+        end
+
+        def table_view(messages)
+          Ribose::CLI::Util.list(
+            headings: ["ID", "User", "Message"], rows: table_rows(messages),
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/ribose/cli/util.rb
+++ b/lib/ribose/cli/util.rb
@@ -9,6 +9,14 @@ module Ribose
           table.rows = rows
         end
       end
+
+      def self.truncate(content, length = 50)
+        if content && content.length > length
+          content = content[0..length] + "..."
+        end
+
+        content
+      end
     end
   end
 end

--- a/spec/acceptance/message_spec.rb
+++ b/spec/acceptance/message_spec.rb
@@ -1,0 +1,15 @@
+require "spec_helper"
+
+RSpec.describe "Conversation Messages" do
+  describe "listing messages" do
+    it "retrieves the list of messages" do
+      command = %w(message list -s 123456789 -c 123456789 --format json)
+
+      stub_ribose_message_list(123456789, 123456789)
+      output = capture_stdout { Ribose::CLI.start(command) }
+
+      expect(output).to match(/"contents":"Welcome to Ribose Space"/)
+      expect(output).to match(/"id":"eec38935-3070-4949-b217-878aa07db699"/)
+    end
+  end
+end


### PR DESCRIPTION
Ribose conversation contains multiple messages, and these are the actual communication under any specific topics. This commit adds the support to list the messages for any specific conversation

```sh
ribose message --space-id 12345 --conversation-id 67890
```