### PR TITLE
Add a new message to a conversation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,4 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in ribose-cli.gemspec
 gemspec
-gem "ribose", github: "riboseinc/ribose-ruby", ref: "6c272f9"
+gem "ribose", github: "riboseinc/ribose-ruby", ref: "5ac5604"

--- a/README.md
+++ b/README.md
@@ -122,6 +122,13 @@ ribose conversation remove --space-id 1234 --conversation-id 5678
 ribose message list --space-id 12345 --conversation-id 56789
 ```
 
+#### Add a new message to conversation
+
+```sh
+ribose message add --space-id 12345 --conversation-id 56789 \
+  --message-body "Welcome to Ribose Space"
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this gem, you can read the

--- a/lib/ribose/cli/commands/message.rb
+++ b/lib/ribose/cli/commands/message.rb
@@ -11,11 +11,29 @@ module Ribose
           say(build_output(list_messages, options))
         end
 
+        desc "add", "Add New Message to Conversation"
+        option :message_body, required: true, aliases: "-b"
+        option :conversation_id, aliases: "-c", required: true
+        option :space_id, required: true, aliases: "-s", desc: "The Space UUID"
+
+        def add
+          message = create_message(options)
+          say("Messge has been posted! Id: " + message.id)
+        end
+
         private
 
         def list_messages
           @messages ||= Ribose::Message.all(
             space_id: options[:space_id],
+            conversation_id: options[:conversation_id],
+          )
+        end
+
+        def create_message(options)
+          Ribose::Message.create(
+            space_id: options[:space_id],
+            contents: options[:message_body],
             conversation_id: options[:conversation_id],
           )
         end

--- a/spec/acceptance/message_spec.rb
+++ b/spec/acceptance/message_spec.rb
@@ -12,4 +12,37 @@ RSpec.describe "Conversation Messages" do
       expect(output).to match(/"id":"eec38935-3070-4949-b217-878aa07db699"/)
     end
   end
+
+  describe "Adding new message" do
+    it "allows us to add message to a conversation" do
+      command = %W(
+        message add
+        --space-id 123
+        --message-body #{message.contents}
+        --conversation-id #{message.conversation_id}
+      )
+
+      stub_ribose_message_create(123, message: message.to_h)
+      output = capture_stdout { Ribose::CLI.start(command) }
+
+      expect(output).to match(/Messge has been posted/)
+      expect(output).to match(/Id: 9af4df9f-2a30-4d66-a925-efaf45057ae4/)
+    end
+  end
+
+  def message
+    @message ||= OpenStruct.new(
+      contents: "Welcome to Ribose!",
+      conversation_id: "987654321",
+    )
+  end
+
+  def stub_ribose_message_create(sid, attributes)
+    cid = attributes[:message][:conversation_id]
+    message_path = "spaces/#{sid}/conversation/conversations/#{cid}/messages"
+
+    stub_api_response(
+      :post, message_path, data: attributes, filename: "message_created"
+    )
+  end
 end


### PR DESCRIPTION
Ribose API allows us to post a message to any conversation, this commit utilizes that interface and creates a CLI command to allow our user to post a new message to their conversation.

```sh
ribose message add \
  --space-id space_uuid \
  --conversation-id conversation_uuid \
  --message-body "Welcome to the Ribose world"
```