### PR TITLE
Add support to edit an existing message

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,4 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in ribose-cli.gemspec
 gemspec
-gem "ribose", github: "riboseinc/ribose-ruby", ref: "5ac5604"
+gem "ribose", github: "riboseinc/ribose-ruby", ref: "693a583"

--- a/README.md
+++ b/README.md
@@ -129,6 +129,14 @@ ribose message add --space-id 12345 --conversation-id 56789 \
   --message-body "Welcome to Ribose Space"
 ```
 
+#### Edit an existing message
+
+
+```sh
+ribose message add --message-id 123456 --space-id 12345 \
+  --conversation-id 56789 --message-body "Welcome to Ribose Space"
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this gem, you can read the

--- a/lib/ribose/cli/commands/message.rb
+++ b/lib/ribose/cli/commands/message.rb
@@ -21,6 +21,17 @@ module Ribose
           say("Messge has been posted! Id: " + message.id)
         end
 
+        desc "edit", "Edit an existing Message"
+        option :message_body, required: true, aliases: "-b"
+        option :message_id, required: true, aliases: "-m"
+        option :conversation_id, aliases: "-c", required: true
+        option :space_id, required: true, aliases: "-s", desc: "The Space UUID"
+
+        def edit
+          update_message(options)
+          say("Messge has been updated!")
+        end
+
         private
 
         def list_messages
@@ -33,6 +44,15 @@ module Ribose
         def create_message(options)
           Ribose::Message.create(
             space_id: options[:space_id],
+            contents: options[:message_body],
+            conversation_id: options[:conversation_id],
+          )
+        end
+
+        def update_message(options)
+          Ribose::Message.update(
+            space_id: options[:space_id],
+            message_id: options[:message_id],
             contents: options[:message_body],
             conversation_id: options[:conversation_id],
           )

--- a/spec/acceptance/message_spec.rb
+++ b/spec/acceptance/message_spec.rb
@@ -30,19 +30,27 @@ RSpec.describe "Conversation Messages" do
     end
   end
 
+  describe "Editing a message" do
+    it "allows us to edit a existing message" do
+      command = %W(
+        message edit
+        --space-id 123
+        --message-id 456789
+        --message-body #{message.contents}
+        --conversation-id #{message.conversation_id}
+      )
+
+      stub_ribose_message_update(123, 456789, message: message.to_h)
+      output = capture_stdout { Ribose::CLI.start(command) }
+
+      expect(output).to match(/Messge has been updated!/)
+    end
+  end
+
   def message
     @message ||= OpenStruct.new(
       contents: "Welcome to Ribose!",
       conversation_id: "987654321",
-    )
-  end
-
-  def stub_ribose_message_create(sid, attributes)
-    cid = attributes[:message][:conversation_id]
-    message_path = "spaces/#{sid}/conversation/conversations/#{cid}/messages"
-
-    stub_api_response(
-      :post, message_path, data: attributes, filename: "message_created"
     )
   end
 end


### PR DESCRIPTION
This commit adds the CLI interface to update an existing message, on successful update this shows a success message to the user. It also do some minor refactoring regarding the stubs helper.

```sh
ribose message edit
  --space-id space_uuid
  --message-id message_uuid
  --conversation-id conversation_uuid
  --message-body "New content for the message"
```