### PR TITLE
Add interface to remove an existing message

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,4 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in ribose-cli.gemspec
 gemspec
-gem "ribose", github: "riboseinc/ribose-ruby", ref: "693a583"
+gem "ribose", github: "riboseinc/ribose-ruby", ref: "4b738bd"

--- a/README.md
+++ b/README.md
@@ -137,6 +137,12 @@ ribose message add --message-id 123456 --space-id 12345 \
   --conversation-id 56789 --message-body "Welcome to Ribose Space"
 ```
 
+#### Remove an existing message
+
+```sh
+ribose message remove --message-id 1234 --space-id 12345 --conversation-id 456
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this gem, you can read the

--- a/lib/ribose/cli/commands/message.rb
+++ b/lib/ribose/cli/commands/message.rb
@@ -32,6 +32,18 @@ module Ribose
           say("Messge has been updated!")
         end
 
+        desc "remove", "Remove A Conversation from Space"
+        option :message_id, required: true, aliases: "-m"
+        option :conversation_id, aliases: "-c", required: true
+        option :space_id, required: true, aliases: "-s", desc: "The Space UUID"
+
+        def remove
+          remove_message(options)
+          say("The message has been removed!")
+        rescue
+          say("Please provide a valid message UUID")
+        end
+
         private
 
         def list_messages
@@ -54,6 +66,14 @@ module Ribose
             space_id: options[:space_id],
             message_id: options[:message_id],
             contents: options[:message_body],
+            conversation_id: options[:conversation_id],
+          )
+        end
+
+        def remove_message(options)
+          Ribose::Message.remove(
+            space_id: options[:space_id],
+            message_id: options[:message_id],
             conversation_id: options[:conversation_id],
           )
         end

--- a/spec/acceptance/message_spec.rb
+++ b/spec/acceptance/message_spec.rb
@@ -47,6 +47,17 @@ RSpec.describe "Conversation Messages" do
     end
   end
 
+  describe "Remove a message" do
+    it "allows us to remove an existing message" do
+      command = %w(message remove -s 123 -c 456 --message-id 123456)
+
+      stub_ribose_message_remove(123, 123456, 456)
+      output = capture_stdout { Ribose::CLI.start(command) }
+
+      expect(output).to match(/The message has been removed!/)
+    end
+  end
+
   def message
     @message ||= OpenStruct.new(
       contents: "Welcome to Ribose!",


### PR DESCRIPTION
The Ribose client offers `.remove` interface to remove any of the existing messages, and this commit adds the CLI command to utilize that behavior and allow a user to remove any of the existing user's message. Usages:

```sh
ribose message remove --message-id 123 --space-id 456 -c 789
```