### PR TITLE
Add interface to upload a file to a space

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,15 @@ ribose file list --space-id 123456
 The above interface will retrieve the basic details in tabular format, but it
 also support additional `format` option, acceptable option: `json`.
 
+#### Add a new file
+
+Ribose CLI allows us to upload a file in a user space, and to upload a new file
+we can use the following interface.
+
+```sh
+ribose file add full_path_the_file.ext  --space-id space_uuid **other_options
+```
+
 ### Conversations
 
 #### Listing conversations

--- a/lib/ribose/cli/commands/file.rb
+++ b/lib/ribose/cli/commands/file.rb
@@ -10,10 +10,32 @@ module Ribose
           say(build_output(list_files(options), options))
         end
 
+        desc "add", "Adding a new fille to a space"
+        option :space_id, required: true, aliases: "-s", desc: "The Space UUID"
+        option :description, aliases: "-d", desc: "The file upload description"
+        option :tag_list, aliases: "-t", desc: "File tags, separated by commas"
+
+        def add(file)
+          file_upload = create_upload(file, options)
+
+          if file_upload.id
+            say("#{file_upload.name} added to your space!")
+          end
+        end
+
         private
 
         def list_files(attributes)
           @files ||= Ribose::SpaceFile.all(attributes[:space_id])
+        end
+
+        def create_upload(file, attributes = {})
+          Ribose::SpaceFile.create(
+            attributes[:space_id],
+            file: file,
+            tag_list: attributes[:tag_list],
+            description: attributes[:description],
+          )
         end
 
         def build_output(files, options)

--- a/spec/acceptance/file_spec.rb
+++ b/spec/acceptance/file_spec.rb
@@ -12,4 +12,23 @@ RSpec.describe "File Interface" do
       expect(output).to match(/"name":"sample-file.png"/)
     end
   end
+
+  describe "adding new file" do
+    it "uploads the new file to user space" do
+      command = %W(file add --space-id 123456 #{file_attributes[:file]})
+
+      stub_ribose_space_file_upload_api(123456, file_attributes)
+      output = capture_stdout { Ribose::CLI.start(command) }
+
+      expect(output).to match(/sample.png added to your space!/)
+    end
+  end
+
+  def file_attributes
+    { file: sample_fixture, description: "", tag_list: "" }
+  end
+
+  def sample_fixture
+    @sample_fixture ||= File.join(Ribose.root, "spec/fixtures/sample.png")
+  end
 end


### PR DESCRIPTION
In the recent ribose ruby, it added the support to upload a file to any userspace. This commit utilizes that interface and provides a CLI command so we can easily upload a file to any space. Usages

```sh
ribose file add --space-id space_uuid path_to_file.ext
```

Related:  #4 