### PR TITLE
Add interface to list notes for a space

### DIFF
--- a/lib/ribose/cli/command.rb
+++ b/lib/ribose/cli/command.rb
@@ -3,12 +3,16 @@ require "ribose/cli/commands/space"
 require "ribose/cli/commands/file"
 require "ribose/cli/commands/conversation"
 require "ribose/cli/commands/message"
+require "ribose/cli/commands/note"
 
 module Ribose
   module CLI
     class Command < Thor
       desc "space", "List, Add or Remove User Space"
       subcommand :space, Ribose::CLI::Commands::Space
+
+      desc "note", "List, Add or Remove Space Note"
+      subcommand :note, Ribose::CLI::Commands::Note
 
       desc "file", "List, Add or Remove Files"
       subcommand :file, Ribose::CLI::Commands::File

--- a/lib/ribose/cli/commands/note.rb
+++ b/lib/ribose/cli/commands/note.rb
@@ -1,0 +1,41 @@
+module Ribose
+  module CLI
+    module Commands
+      class Note < Thor
+        desc "list", "Listing notes for a user space"
+        option :format, aliases: "-f", desc: "Output format, eg: json"
+        option :space_id, required: true, aliases: "-s", desc: "The Space UUID"
+
+        def list
+          say(build_output(list_notes(options), options))
+        end
+
+        private
+
+        def list_notes(attributes)
+          @notes ||= Ribose::Wiki.all(attributes[:space_id])
+        end
+
+        def build_output(notes, options)
+          json_view(notes, options) || table_view(notes)
+        end
+
+        def json_view(notes, options)
+          if options[:format] == "json"
+            notes.map(&:to_h).to_json
+          end
+        end
+
+        def table_rows(notes)
+          notes.map { |note| [note.id, note.name, note.revision] }
+        end
+
+        def table_view(notes)
+          Ribose::CLI::Util.list(
+            headings: ["ID", "Name", "Revisions"], rows: table_rows(notes),
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/acceptance/note_spec.rb
+++ b/spec/acceptance/note_spec.rb
@@ -1,0 +1,15 @@
+require "spec_helper"
+
+RSpec.describe "Space Note" do
+  describe "listing notes" do
+    it "retrieves the list of notes" do
+      command = %w(note list --space-id 123456789)
+
+      stub_ribose_wiki_list_api(123_456_789)
+      output = capture_stdout { Ribose::CLI.start(command) }
+
+      expect(output).to match(/Wiki Page One/)
+      expect(output).to match(/Wiki Page Two/)
+    end
+  end
+end


### PR DESCRIPTION
Ribose client offers `Ribose::Wiki` interface that provides us the list of notes for a user's space, and this commit usage that and adds a CLI interface to list those notes. Usages:

```sh
ribose space list --space-id the-space-uuid
```

Screenshot:

<img width="472" alt="screenshot 2017-12-05 15 22 47" src="https://user-images.githubusercontent.com/1220911/33596918-39c74fe4-d9d0-11e7-88b2-58434643fd35.png">


Related: Issue #6 