### PR TITLE
Add interface to create a new note

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,20 @@ ribose space add --name "Space name" --access "open" --category-id 12 \
 ribose space remove --space-id 123456789 --confirmation 123456789
 ```
 
+### Note
+
+#### Listing space notes
+
+```sh
+ribose note list --space-id space_uuid --format json
+```
+
+#### Create a new note
+
+```sh
+ribose note add --space-id space_uuid --title "Name of the note"
+```
+
 ### Files
 
 #### Listing files

--- a/lib/ribose/cli/commands/note.rb
+++ b/lib/ribose/cli/commands/note.rb
@@ -10,10 +10,28 @@ module Ribose
           say(build_output(list_notes(options), options))
         end
 
+        desc "add", "Add a new note to a user space"
+        option :title, required: true, desc: "The title for the note"
+        option :tag_list, aliases: "-t", desc: "Note tags, separated by commas"
+        option :space_id, required: true, aliases: "-s", desc: "The Space UUID"
+
+        def add
+          note = create_note(options)
+          say("Note has been posted added! Id: " + note.id.to_s)
+        end
+
         private
 
         def list_notes(attributes)
           @notes ||= Ribose::Wiki.all(attributes[:space_id])
+        end
+
+        def create_note(attributes)
+          Ribose::Wiki.create(
+            attributes[:space_id],
+            name: attributes[:title],
+            tag_list: attributes[:tag_list],
+          )
         end
 
         def build_output(notes, options)

--- a/spec/acceptance/note_spec.rb
+++ b/spec/acceptance/note_spec.rb
@@ -12,4 +12,15 @@ RSpec.describe "Space Note" do
       expect(output).to match(/Wiki Page Two/)
     end
   end
+
+  describe "adding a new note" do
+    it "adds a new note to a specific space" do
+      command = %w(note add -s 123456 --title Home)
+      stub_ribose_wiki_create_api(123_456, tag_list: nil, name: "Home")
+
+      output = capture_stdout { Ribose::CLI.start(command) }
+
+      expect(output).to match(/Note has been posted added! Id:/)
+    end
+  end
 end


### PR DESCRIPTION
This commit usage the note creation interfaces from the ruby client and then provides a command line friendlier interface so we can easily create a new note in any space.

```sh
ribose note add --space-id space_uuid --title "Note title"
```

Help Doc:

<img width="611" alt="screenshot 2017-12-05 16 58 53" src="https://user-images.githubusercontent.com/1220911/33601049-aa4ad3f0-d9dd-11e7-9c30-9b36e1a0212a.png">


Related: Issue #6