### PR TITLE
Add interface to remove a space note

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,12 @@ ribose note list --space-id space_uuid --format json
 ribose note add --space-id space_uuid --title "Name of the note"
 ```
 
+#### Remove a note
+
+```sh
+ribose note remove --space-id space_uuid --note-id note_uuid
+```
+
 ### Files
 
 #### Listing files

--- a/lib/ribose/cli/commands/note.rb
+++ b/lib/ribose/cli/commands/note.rb
@@ -20,6 +20,17 @@ module Ribose
           say("Note has been posted added! Id: " + note.id.to_s)
         end
 
+        desc "remove", "Removes a note from a space"
+        option :note_id, required: true, aliases: "-n", desc: "The Note UUID"
+        option :space_id, required: true, aliases: "-s", desc: "The Space UUID"
+
+        def remove
+          remove_note(options)
+          say("The note has been removed!")
+        rescue
+          say("Could not remove the specified note")
+        end
+
         private
 
         def list_notes(attributes)
@@ -30,8 +41,12 @@ module Ribose
           Ribose::Wiki.create(
             attributes[:space_id],
             name: attributes[:title],
-            tag_list: attributes[:tag_list],
+            tag_list: attributes[:tag_list] || "",
           )
+        end
+
+        def remove_note(attributes)
+          Ribose::Wiki.delete(attributes[:space_id], attributes[:note_id])
         end
 
         def build_output(notes, options)

--- a/spec/acceptance/note_spec.rb
+++ b/spec/acceptance/note_spec.rb
@@ -15,12 +15,23 @@ RSpec.describe "Space Note" do
 
   describe "adding a new note" do
     it "adds a new note to a specific space" do
-      command = %w(note add -s 123456 --title Home)
-      stub_ribose_wiki_create_api(123_456, tag_list: nil, name: "Home")
+      command = %w(note add -s 123456 --title Home --tag-list hello)
+      stub_ribose_wiki_create_api(123_456, tag_list: "hello", name: "Home")
 
       output = capture_stdout { Ribose::CLI.start(command) }
 
       expect(output).to match(/Note has been posted added! Id:/)
+    end
+  end
+
+  describe "remove a note" do
+    it "removes a note from a specific space" do
+      command = %w(note remove -s 123456789 --note-id 789123456)
+
+      stub_ribose_wiki_delete_api(123456789, 789123456)
+      output = capture_stdout { Ribose::CLI.start(command) }
+
+      expect(output).to match(/The note has been removed!/)
     end
   end
 end


### PR DESCRIPTION
Ribose API allows us to delete a note from any specific space, and this commit usages that interface and provide a cli command for that so we can easily remove any note. Usage:

```sh
ribose note remove --space-id space_uuid --note-id note_uuid
```

Related: Issue #6