### PR TITLE
Extract output helpers to a base class

### DIFF
--- a/lib/ribose/cli/command.rb
+++ b/lib/ribose/cli/command.rb
@@ -1,4 +1,5 @@
 require "ribose/cli/rcfile"
+require "ribose/cli/commands/base"
 require "ribose/cli/commands/space"
 require "ribose/cli/commands/file"
 require "ribose/cli/commands/conversation"

--- a/lib/ribose/cli/commands/base.rb
+++ b/lib/ribose/cli/commands/base.rb
@@ -1,0 +1,33 @@
+module Ribose
+  module CLI
+    module Commands
+      class Base < Thor
+        private
+
+        def table_headers
+          raise NotImplementedError
+        end
+
+        def table_rows
+          raise NotImplementedError
+        end
+
+        def build_output(resources, options)
+          json_view(resources, options) || table_view(resources)
+        end
+
+        def json_view(resources, options)
+          if options[:format] == "json"
+            resources.map(&:to_h).to_json
+          end
+        end
+
+        def table_view(resources)
+          Ribose::CLI::Util.list(
+            headings: table_headers, rows: table_rows(resources),
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/ribose/cli/commands/conversation.rb
+++ b/lib/ribose/cli/commands/conversation.rb
@@ -1,7 +1,7 @@
 module Ribose
   module CLI
     module Commands
-      class Conversation < Thor
+      class Conversation < Commands::Base
         desc "list", "Listing A Space Conversations"
         option :format, aliases: "-f", desc: "Output format, eg: json"
         option :space_id, required: true, aliases: "-s", desc: "The Space UUID"
@@ -50,24 +50,12 @@ module Ribose
           )
         end
 
-        def build_output(conversations, options)
-          json_view(conversations, options) || table_view(conversations)
-        end
-
-        def json_view(conversations, options)
-          if options[:format] == "json"
-            conversations.map(&:to_h).to_json
-          end
+        def table_headers
+          ["ID", "Title"]
         end
 
         def table_rows(conversations)
           conversations.map { |conv| [conv.id, conv.name] }
-        end
-
-        def table_view(conversations)
-          Ribose::CLI::Util.list(
-            headings: ["ID", "Title"], rows: table_rows(conversations),
-          )
         end
       end
     end

--- a/lib/ribose/cli/commands/file.rb
+++ b/lib/ribose/cli/commands/file.rb
@@ -1,7 +1,7 @@
 module Ribose
   module CLI
     module Commands
-      class File < Thor
+      class File < Commands::Base
         desc "list", "Listing the files for a space"
         option :format, aliases: "-f", desc: "Output format, eg: json"
         option :space_id, required: true, aliases: "-s", desc: "The Space UUID"
@@ -38,24 +38,12 @@ module Ribose
           )
         end
 
-        def build_output(files, options)
-          json_view(files, options) || table_view(files)
-        end
-
-        def json_view(files, options)
-          if options[:format] == "json"
-            files.map(&:to_h).to_json
-          end
+        def table_headers
+          ["ID", "Name", "Versions"]
         end
 
         def table_rows(files)
           files.map { |file| [file.id, file.name, file.version] }
-        end
-
-        def table_view(files)
-          Ribose::CLI::Util.list(
-            headings: ["ID", "Name", "Versions"], rows: table_rows(files),
-          )
         end
       end
     end

--- a/lib/ribose/cli/commands/message.rb
+++ b/lib/ribose/cli/commands/message.rb
@@ -1,7 +1,7 @@
 module Ribose
   module CLI
     module Commands
-      class Message < Thor
+      class Message < Commands::Base
         desc "list", "Listing Messages"
         option :conversation_id, aliases: "-c", required: true
         option :format, aliases: "-f", desc: "Output format, eg: json"
@@ -78,31 +78,19 @@ module Ribose
           )
         end
 
-        def build_output(messages, options)
-          json_view(messages, options) || table_view(messages)
+        def sanitize(content, length = 30)
+          content = content.to_s.gsub(/<\/?[^>]*>/, "")
+          Ribose::CLI::Util.truncate(content, length)
         end
 
-        def json_view(messages, options)
-          if options[:format] == "json"
-            messages.map(&:to_h).to_json
-          end
+        def table_headers
+          ["ID", "User", "Message"]
         end
 
         def table_rows(messages)
           messages.map do |message|
             [message.id, message.user.name, sanitize(message.contents)]
           end
-        end
-
-        def sanitize(content, length = 30)
-          content = content.to_s.gsub(/<\/?[^>]*>/, "")
-          Ribose::CLI::Util.truncate(content, length)
-        end
-
-        def table_view(messages)
-          Ribose::CLI::Util.list(
-            headings: ["ID", "User", "Message"], rows: table_rows(messages),
-          )
         end
       end
     end

--- a/lib/ribose/cli/commands/note.rb
+++ b/lib/ribose/cli/commands/note.rb
@@ -1,7 +1,7 @@
 module Ribose
   module CLI
     module Commands
-      class Note < Thor
+      class Note < Commands::Base
         desc "list", "Listing notes for a user space"
         option :format, aliases: "-f", desc: "Output format, eg: json"
         option :space_id, required: true, aliases: "-s", desc: "The Space UUID"
@@ -49,24 +49,12 @@ module Ribose
           Ribose::Wiki.delete(attributes[:space_id], attributes[:note_id])
         end
 
-        def build_output(notes, options)
-          json_view(notes, options) || table_view(notes)
-        end
-
-        def json_view(notes, options)
-          if options[:format] == "json"
-            notes.map(&:to_h).to_json
-          end
+        def table_headers
+          ["ID", "Name", "Revisions"]
         end
 
         def table_rows(notes)
           notes.map { |note| [note.id, note.name, note.revision] }
-        end
-
-        def table_view(notes)
-          Ribose::CLI::Util.list(
-            headings: ["ID", "Name", "Revisions"], rows: table_rows(notes),
-          )
         end
       end
     end

--- a/lib/ribose/cli/commands/space.rb
+++ b/lib/ribose/cli/commands/space.rb
@@ -1,7 +1,7 @@
 module Ribose
   module CLI
     module Commands
-      class Space < Thor
+      class Space < Commands::Base
         desc "list", "List user spaces"
         option :format, aliases: "-f", desc: "Output format, eg: json"
 
@@ -53,24 +53,12 @@ module Ribose
           )
         end
 
-        def build_output(spaces, options)
-          json_view(spaces, options) || table_view(spaces)
-        end
-
-        def json_view(spaces, options)
-          if options[:format] == "json"
-            spaces.map(&:to_h).to_json
-          end
+        def table_headers
+          ["ID", "Name", "Active?"]
         end
 
         def table_rows(spaces)
           spaces.map { |space| [space.id, space.name, space.active ] }
-        end
-
-        def table_view(spaces)
-          Ribose::CLI::Util.list(
-            headings: ["ID", "Name", "Active?"], rows: table_rows(spaces),
-          )
         end
       end
     end


### PR DESCRIPTION
Most of the command line utilities are using some helper methods again and again to build the output based on a provided option. This commit simplify those by adding a base class, and add some hook method that we can to set command specific attributes.