### PR TITLE
Add interface to update a user space

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ ribose space add --name "Space name" --access "open" --category-id 12 \
   --description "Space description"
 ```
 
+#### Update a space
+
+```sh
+ribose space update --space-id 123456 --name "New Space Name"
+```
+
 #### Remove an existing space
 
 ```sh

--- a/lib/ribose/cli/commands/base.rb
+++ b/lib/ribose/cli/commands/base.rb
@@ -27,6 +27,14 @@ module Ribose
             headings: table_headers, rows: table_rows(resources),
           )
         end
+
+        def symbolize_keys(options_hash)
+          Hash.new.tap do |hash|
+            options_hash.each_key do |key|
+              hash[(key.to_sym rescue key) || key] = options_hash.fetch(key)
+            end
+          end
+        end
       end
     end
   end

--- a/lib/ribose/cli/commands/space.rb
+++ b/lib/ribose/cli/commands/space.rb
@@ -10,14 +10,29 @@ module Ribose
         end
 
         desc "add", "Add a new user space"
+        option :name, aliases: "-n", desc: "Name of the space"
+        option :description, desc: "The description for space"
+        option :category_id, desc: "The category for this space"
+        option :access, default: "open", desc: "The visiblity for the space"
+
+        def add
+          space = Ribose::Space.create(symbolize_keys(options))
+          say("New Space created! Id: " + space.id)
+        end
+
+        desc "update", "Update an existing space"
+        option :space_id, required: true, desc: "The Space UUID"
         option :access, desc: "The visiblity for the space"
         option :name, aliases: "-n", desc: "Name of the space"
         option :description, desc: "The description for space"
         option :category_id, desc: "The category for this space"
 
-        def add
-          space = create_space(options)
-          say("New Space created! Id: " + space.id)
+        def update
+          attributes = symbolize_keys(options)
+          Ribose::Space.update(attributes.delete(:space_id), attributes)
+          say("Your space has been updated!")
+        rescue Ribose::UnprocessableEntity
+          say("Something went wrong!, please check required attributes")
         end
 
         desc "remove", "Remove an existing space"
@@ -35,15 +50,6 @@ module Ribose
 
         def list_user_spaces
           @user_spaces ||= Ribose::Space.all
-        end
-
-        def create_space(attributes)
-          Ribose::Space.create(
-            name: attributes[:name],
-            access: attributes[:access] || "open",
-            description: attributes[:description],
-            category_id: attributes[:category_id],
-          )
         end
 
         def remove_space(attributes)

--- a/spec/acceptance/space_spec.rb
+++ b/spec/acceptance/space_spec.rb
@@ -45,6 +45,24 @@ RSpec.describe "Ribose Space" do
     end
   end
 
+  describe "Updating a space" do
+    it "updates an existing user space" do
+      command = %W(
+        space update
+        --space-id 123456789
+        --access #{space.access}
+        --description #{space.description}
+        --category-id #{space.category_id}
+        --name #{space.name}
+      )
+
+      stub_ribose_space_update_api(123456789, space.to_h)
+      output = capture_stdout { Ribose::CLI.start(command) }
+
+      expect(output).to match(/Your space has been updated!/)
+    end
+  end
+
   describe "Remove an existing space" do
     it "removes an existing space" do
       space_uuid = "6b2741ad-4cde-4b4d-af3b-a162a4f6bc25"


### PR DESCRIPTION
The Ribose client offers `Ribose::Space.update` interface to update any of the existing space. This commit adds the command line interface that will allow us to update a space using that

```sh
ribose space update --space-id 123456 --name "New Space Name"
```