### PR TITLE
Add interface to retrieve a space details

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ This interface also has support `json` format, if we want the output to be in
 ribose space list --format json
 ```
 
+#### Show a space details
+
+```sh
+ribose space show --space-id 123456789
+```
+
 #### Create a new space
 
 To create a new user space we can use the following interface

--- a/lib/ribose/cli/commands/base.rb
+++ b/lib/ribose/cli/commands/base.rb
@@ -4,16 +4,42 @@ module Ribose
       class Base < Thor
         private
 
+        # Table Headers
+        #
+        # Listing resources in table view will invoke this method to
+        # retrieve the list of headers, please override this in the
+        # sub-class and fill it in with actual fields name.
+        #
         def table_headers
           raise NotImplementedError
         end
 
+        # Table Rows
+        #
+        # List resources in table view will invoke this method to build
+        # each of the individual resource row, please override this with
+        # an array that includes the value for headers.
+        #
         def table_rows
+          raise NotImplementedError
+        end
+
+        # Table field names
+        #
+        # Displaying a single resource in table view will invoke this
+        # method to figure out field name and values for each of the
+        # row in table, please override this with proper attributes
+        #
+        def table_field_names
           raise NotImplementedError
         end
 
         def build_output(resources, options)
           json_view(resources, options) || table_view(resources)
+        end
+
+        def build_resource_output(resource, options)
+          resource_as_json(resource, options) || resource_as_table(resource)
         end
 
         def json_view(resources, options)
@@ -22,9 +48,22 @@ module Ribose
           end
         end
 
+        def resource_as_json(resource, options)
+          if options[:format] == "json"
+            resource.to_h.to_json
+          end
+        end
+
         def table_view(resources)
           Ribose::CLI::Util.list(
             headings: table_headers, rows: table_rows(resources),
+          )
+        end
+
+        def resource_as_table(resource)
+          Ribose::CLI::Util.list(
+            headings: ["Field", "Value"],
+            rows: table_field_names.map { |key| [key, resource[key.to_s]] },
           )
         end
 

--- a/lib/ribose/cli/commands/space.rb
+++ b/lib/ribose/cli/commands/space.rb
@@ -9,6 +9,15 @@ module Ribose
           say(build_output(list_user_spaces, options))
         end
 
+        desc "show", "Details for a space"
+        option :space_id, aliases: "-s", description: "The Space UUID"
+        option :format, aliases: "-f", desc: "Output format, eg: json"
+
+        def show
+          space = Ribose::Space.fetch(options[:space_id])
+          say(build_resource_output(space, options))
+        end
+
         desc "add", "Add a new user space"
         option :name, aliases: "-n", desc: "Name of the space"
         option :description, desc: "The description for space"
@@ -65,6 +74,11 @@ module Ribose
 
         def table_rows(spaces)
           spaces.map { |space| [space.id, space.name, space.active ] }
+        end
+
+        # Single resource fields
+        def table_field_names
+          %w(id name visibility active members_count role_name)
         end
       end
     end

--- a/spec/acceptance/space_spec.rb
+++ b/spec/acceptance/space_spec.rb
@@ -27,6 +27,32 @@ RSpec.describe "Ribose Space" do
     end
   end
 
+  describe "Retrieving a space" do
+    context "with default options" do
+      it "displays the space in tabular format" do
+        command = %w(space show --space-id 123456789)
+
+        stub_ribose_space_fetch_api(123_456_789)
+        output = capture_stdout { Ribose::CLI.start(command) }
+
+        expect(output).to match(/name          | Work/)
+        expect(output).to match(/visibility    | invisible/)
+      end
+    end
+
+    context "with format option" do
+      it "displays as the space in supported format" do
+        command = %w(space show --space-id 123456789 --format json)
+
+        stub_ribose_space_fetch_api(123_456_789)
+        output = capture_stdout { Ribose::CLI.start(command) }
+
+        expect(output).to match(/"name":"Work"/)
+        expect(output).to match(/"id":"0e8d5c16-1a31-4df9-83d9-eeaa374d5adc"/)
+      end
+    end
+  end
+
   describe "Adding a new space" do
     it "allows us to add a new space" do
       command = %W(


### PR DESCRIPTION
This commit adds a command line interface to retrieve the details for any specific space, by default it would show the space in a tabular format, but the user can change the output using a `format` option. Usages:

```sh
ribose show --space-id 123456789
```

Screenshot:

<img width="678" alt="screenshot 2017-12-15 15 34 33" src="https://user-images.githubusercontent.com/1220911/34033749-17cf810a-e1ae-11e7-9b43-8630fb0e8406.png">
