### PR TITLE
Add interface to retrieve a conversation

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,12 @@ ribose file add full_path_the_file.ext  --space-id space_uuid **other_options
 ribose conversation list --space-id 123456789
 ```
 
+#### Show a conversation details
+
+```sh
+ribose conversation show --space-id 123456789 --conversation-id 67890
+```
+
 #### Create A New Conversation
 
 ```sh

--- a/lib/ribose/cli/commands/conversation.rb
+++ b/lib/ribose/cli/commands/conversation.rb
@@ -10,6 +10,21 @@ module Ribose
           say(build_output(list_conversations, options))
         end
 
+        desc "show", "Show the details for a conversation"
+        option :space_id, required: true, aliases: "-s", desc: "The Space UUID"
+        option :format, aliases: "-f", desc: "Output format, eg: json"
+
+        option(
+          :conversation_id,
+          required: true,
+          aliases: "-c",
+          desc: "The Conversation UUID",
+        )
+
+        def show
+          say(build_resource_output(conversation(options), options))
+        end
+
         desc "add", "Add a new conversation to Space"
         option :space_id, required: true, aliases: "-s", desc: "The Space UUID"
         option :title, required: true, desc: "The title for the conversation"
@@ -33,6 +48,12 @@ module Ribose
 
         private
 
+        def conversation(attributes)
+          @conversation ||= Ribose::Conversation.fetch(
+            attributes[:space_id], attributes[:conversation_id]
+          )
+        end
+
         def list_conversations
           @conversations ||= Ribose::Conversation.all(options[:space_id])
         end
@@ -52,6 +73,10 @@ module Ribose
 
         def table_headers
           ["ID", "Title"]
+        end
+
+        def table_field_names
+          %w(id space_id name number_of_messages allow_comment)
         end
 
         def table_rows(conversations)

--- a/spec/acceptance/conversation_spec.rb
+++ b/spec/acceptance/conversation_spec.rb
@@ -13,6 +13,18 @@ RSpec.describe "Space Conversation" do
     end
   end
 
+  describe "Retrieving a conversation" do
+    it "retrieves the details for a conversation" do
+      command = %w(conversation show --space-id 12345 --conversation-id 6789)
+
+      stub_ribose_space_conversation_fetch_api(12345, 6789)
+      output = capture_stdout { Ribose::CLI.start(command) }
+
+      expect(output).to match(/number_of_messages | 1/)
+      expect(output).to match(/name               | Trips to the Mars!/)
+    end
+  end
+
   describe "Adding a new conversations" do
     it "creates a new conversation into a user space" do
       command = %W(


### PR DESCRIPTION
This commit usage the `Ribose::Conversation.fetch` interface and provide a command line interface for that, by default it will show some basic attributes in tabular format, but we can customize it using the `format` option. Usages:

```sh
ribose conversation show -s space_uuid --conversation-id 123
```

Screenshot:

<img width="635" alt="screenshot 2017-12-18 12 58 49" src="https://user-images.githubusercontent.com/1220911/34092046-f942c02e-e3f3-11e7-9182-b4a2baee3e6f.png">

