### PR TITLE
Add interface to update a conversation

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,13 @@ ribose conversation add --space-id 123456789 --title "Conversation Title" \
   --tags "sample, conversation"
 ```
 
+#### Update a conversation
+
+```sh
+conversation update --conversation-id 5678 --space-id 123456789 --title \
+"Conversation Title" --tags "sample, conversation"
+```
+
 #### Remove A Conversation
 
 ```sh

--- a/lib/ribose/cli/commands/conversation.rb
+++ b/lib/ribose/cli/commands/conversation.rb
@@ -35,6 +35,24 @@ module Ribose
           say("New Conversation created! Id: " + conversation.id)
         end
 
+        desc "update", "Updae an existing conversation"
+        option :title, desc: "The title for the conversation"
+        option :tags, aliases: "-t", desc: "The tags for the conversation"
+        option :space_id, required: true, aliases: "-s", desc: "The Space UUID"
+        option(
+          :conversation_id,
+          required: true,
+          aliases: "-c",
+          desc: "The conversation UUID",
+        )
+
+        def update
+          update_conversation(symbolize_keys(options))
+          say("Your conversation has been updated!")
+        rescue Ribose::UnprocessableEntity
+          say("Something went wrong!, please check required attributes")
+        end
+
         desc "remove", "Remove A Conversation from Space"
         option :space_id, required: true, aliases: "-s", desc: "The Space UUID"
         option :conversation_id, required: true, aliases: "-c"
@@ -61,6 +79,14 @@ module Ribose
         def create_conversation(options)
           Ribose::Conversation.create(
             options[:space_id], name: options[:title], tag_list: options[:tags]
+          )
+        end
+
+        def update_conversation(attributes)
+          Ribose::Conversation.update(
+            attributes.delete(:space_id),
+            attributes.delete(:conversation_id),
+            attributes,
           )
         end
 

--- a/spec/acceptance/conversation_spec.rb
+++ b/spec/acceptance/conversation_spec.rb
@@ -42,6 +42,26 @@ RSpec.describe "Space Conversation" do
     end
   end
 
+  describe "Update an existing conversation" do
+    it "updates details for an existing conversation" do
+      command = %W(
+        conversation update
+        --conversation-id 123456789
+        --space-id #{conversation.space_id}
+        --title #{conversation.title}
+        --tags #{conversation.tags}
+      )
+
+      stub_ribose_space_conversation_update_api(
+        123_456_789, 123_456_789, conversation.to_h
+      )
+
+      output = capture_stdout { Ribose::CLI.start(command) }
+
+      expect(output).to match(/Your conversation has been updated!/)
+    end
+  end
+
   describe "Remove a conversation" do
     it "removes a conversation from a speace" do
       command = %w(conversation remove -s 9876 --conversation-id 12345)


### PR DESCRIPTION
This commit usages the conversation interface and provides a cli interface for that, it expects the same attributes as the `add` interface without making the fields required. Usages:

```sh
conversation update --conversation-id 5678 --space-id 123456789 \
      --title "Conversation Title" --tags "sample, conversation"
```