### PR TITLE
Rename message `edit` interface to `update`

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,11 +183,11 @@ ribose message add --space-id 12345 --conversation-id 56789 \
   --message-body "Welcome to Ribose Space"
 ```
 
-#### Edit an existing message
+#### Update an existing message
 
 
 ```sh
-ribose message add --message-id 123456 --space-id 12345 \
+ribose message update --message-id 123456 --space-id 12345 \
   --conversation-id 56789 --message-body "Welcome to Ribose Space"
 ```
 

--- a/lib/ribose/cli/commands/message.rb
+++ b/lib/ribose/cli/commands/message.rb
@@ -21,13 +21,13 @@ module Ribose
           say("Messge has been posted! Id: " + message.id)
         end
 
-        desc "edit", "Edit an existing Message"
+        desc "update", "Update an existing Message"
         option :message_body, required: true, aliases: "-b"
         option :message_id, required: true, aliases: "-m"
         option :conversation_id, aliases: "-c", required: true
         option :space_id, required: true, aliases: "-s", desc: "The Space UUID"
 
-        def edit
+        def update
           update_message(options)
           say("Messge has been updated!")
         end

--- a/spec/acceptance/message_spec.rb
+++ b/spec/acceptance/message_spec.rb
@@ -30,10 +30,10 @@ RSpec.describe "Conversation Messages" do
     end
   end
 
-  describe "Editing a message" do
-    it "allows us to edit a existing message" do
+  describe "Updating a message" do
+    it "allows us to update a existing message" do
       command = %W(
-        message edit
+        message update
         --space-id 123
         --message-id 456789
         --message-body #{message.contents}


### PR DESCRIPTION
In most of the interfaces, we have been using the `update` as interface name, but previously we used to call it `edit`, so to keep things consistence let's rename this interface to update.