### PR TITLE
Add interface to retrieve a note details

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ ribose space remove --space-id 123456789 --confirmation 123456789
 ribose note list --space-id space_uuid --format json
 ```
 
+### Show a space note
+
+```sh
+ribose note show --note-id 123456 --space-id 78901
+```
+
 #### Create a new note
 
 ```sh

--- a/lib/ribose/cli/commands/note.rb
+++ b/lib/ribose/cli/commands/note.rb
@@ -10,6 +10,16 @@ module Ribose
           say(build_output(list_notes(options), options))
         end
 
+        desc "show", "Show details for a note"
+        option :format, aliases: "-f", desc: "Output format, eg: json"
+        option :note_id, required: true, aliases: "-n", desc: "The Note UUID"
+        option :space_id, required: true, aliases: "-s", desc: "The Space UUID"
+
+        def show
+          note = Ribose::Wiki.fetch(options[:space_id], options[:note_id])
+          say(build_resource_output(note, options))
+        end
+
         desc "add", "Add a new note to a user space"
         option :title, required: true, desc: "The title for the note"
         option :tag_list, aliases: "-t", desc: "Note tags, separated by commas"
@@ -51,6 +61,10 @@ module Ribose
 
         def table_headers
           ["ID", "Name", "Revisions"]
+        end
+
+        def table_field_names
+          %w(id space_id name address version revision tag_list)
         end
 
         def table_rows(notes)

--- a/spec/acceptance/note_spec.rb
+++ b/spec/acceptance/note_spec.rb
@@ -13,6 +13,19 @@ RSpec.describe "Space Note" do
     end
   end
 
+  describe "retrieve a note" do
+    it "retrieves the details for a note" do
+      command = %w(note show --space-id 123456 --note-id 789012)
+
+      stub_ribose_wiki_fetch_api(123456, 789012)
+      output = capture_stdout { Ribose::CLI.start(command) }
+
+      expect(output).to match(/revision | 23/)
+      expect(output).to match(/name     | Wiki Page One/)
+      expect(output).to match(/address  | wiki-page-one/)
+    end
+  end
+
   describe "adding a new note" do
     it "adds a new note to a specific space" do
       command = %w(note add -s 123456 --title Home --tag-list hello)


### PR DESCRIPTION
This commit usages the `Ribose::Wiki.fetch` interface and provides a command line interface for that. By default it will show the note in tabular format but we can change that by passing `format` option

```sh
ribose note show --note-id 12345 --space-id 678901
```