### PR TITLE
Add interface to update a space note

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,12 @@ ribose note show --note-id 123456 --space-id 78901
 ribose note add --space-id space_uuid --title "Name of the note"
 ```
 
+#### Update an existing note
+
+```sh
+ribose note update --space-id 1234 --note-id 5678 --title "Name of the note"
+```
+
 #### Remove a note
 
 ```sh

--- a/lib/ribose/cli/commands/note.rb
+++ b/lib/ribose/cli/commands/note.rb
@@ -30,6 +30,19 @@ module Ribose
           say("Note has been posted added! Id: " + note.id.to_s)
         end
 
+        desc "update", "Update details for an existing note"
+        option :note_id, required: true, aliases: "-n", desc: "The Note UUID"
+        option :space_id, required: true, aliases: "-s", desc: "The Space UUID"
+        option :title, desc: "The title for the note"
+        option :tag_list, aliases: "-t", desc: "Note tags, separated by commas"
+
+        def update
+          update_note(options)
+          say("Your space note has been updated!")
+        rescue Ribose::UnprocessableEntity
+          say("Something went wrong!, please check required attributes")
+        end
+
         desc "remove", "Removes a note from a space"
         option :note_id, required: true, aliases: "-n", desc: "The Note UUID"
         option :space_id, required: true, aliases: "-s", desc: "The Space UUID"
@@ -51,6 +64,15 @@ module Ribose
           Ribose::Wiki.create(
             attributes[:space_id],
             name: attributes[:title],
+            tag_list: attributes[:tag_list] || "",
+          )
+        end
+
+        def update_note(attributes)
+          Ribose::Wiki.update(
+            attributes[:space_id],
+            attributes[:note_id],
+            name: attributes[:title] || "",
             tag_list: attributes[:tag_list] || "",
           )
         end

--- a/spec/acceptance/note_spec.rb
+++ b/spec/acceptance/note_spec.rb
@@ -37,6 +37,17 @@ RSpec.describe "Space Note" do
     end
   end
 
+  describe "update a note" do
+    it "updates the details for an existing note" do
+      command = %w(note update -s 1234 -n 5678 --title Sample)
+      stub_ribose_wiki_update_api(1234, 5678, name: "Sample", tag_list: "")
+
+      output = capture_stdout { Ribose::CLI.start(command) }
+
+      expect(output).to match(/Your space note has been updated!/)
+    end
+  end
+
   describe "remove a note" do
     it "removes a note from a specific space" do
       command = %w(note remove -s 123456789 --note-id 789123456)


### PR DESCRIPTION
This commit usage the `Ribose::Wiki.update` interface and provides command line interface to update any specific user note, and on the successful update it prints out the success message.

```sh
ribose note update --space-id 1234 --note-id 5678 --title "New note title"
```