### PR TITLE
Add interface to retrieve space members

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,14 @@ ribose space update --space-id 123456 --name "New Space Name"
 ribose space remove --space-id 123456789 --confirmation 123456789
 ```
 
+### Members
+
+#### List space members
+
+```sh
+ribose member list --space-id space_uuid
+```
+
 ### Note
 
 #### Listing space notes

--- a/lib/ribose/cli/command.rb
+++ b/lib/ribose/cli/command.rb
@@ -5,12 +5,16 @@ require "ribose/cli/commands/file"
 require "ribose/cli/commands/conversation"
 require "ribose/cli/commands/message"
 require "ribose/cli/commands/note"
+require "ribose/cli/commands/member"
 
 module Ribose
   module CLI
     class Command < Thor
       desc "space", "List, Add or Remove User Space"
       subcommand :space, Ribose::CLI::Commands::Space
+
+      desc "member", "List, Add or Remove Space Member"
+      subcommand :member, Ribose::CLI::Commands::Member
 
       desc "note", "List, Add or Remove Space Note"
       subcommand :note, Ribose::CLI::Commands::Note

--- a/lib/ribose/cli/commands/member.rb
+++ b/lib/ribose/cli/commands/member.rb
@@ -1,0 +1,27 @@
+module Ribose
+  module CLI
+    module Commands
+      class Member < Commands::Base
+        desc "list", "List space members"
+        option :format, aliases: "-f", desc: "Output format, eg: json"
+        option :space_id, required: true, alias: "-s", desc: "The Space UUID"
+
+        def list
+          say(build_output(Ribose::Member.all(options[:space_id]), options))
+        end
+
+        private
+
+        def table_headers
+          ["ID", "Name", "Role Name"]
+        end
+
+        def table_rows(members)
+          members.map do |member|
+            [member.user_id, member.user.name, member.role_name_in_space]
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/acceptance/member_spec.rb
+++ b/spec/acceptance/member_spec.rb
@@ -1,0 +1,15 @@
+require "spec_helper"
+
+RSpec.describe "Space Member" do
+  describe "list" do
+    it "retrieves the list of space members" do
+      command = %w(member list --space-id 123456)
+
+      stub_ribose_space_member_list(123456)
+      output = capture_stdout { Ribose::CLI.start(command) }
+
+      expect(output).to match(/| Name     | Role Name/)
+      expect(output).to match(/8332-fcdaecb13e34 | John Doe | Administrator/)
+    end
+  end
+end


### PR DESCRIPTION
The ribose client offers `Ribose::Member` interface that allows us to retrieve the list of members for any specific space. This commit usage that interface and provides a command line interface for that. By default, it shows some basic data in tabular format, but we can customize that by using the `format` option.

```sh
ribose member list --space-id space_uuid
```

Screenshot:

<img width="545" alt="screenshot 2017-12-19 13 53 36" src="https://user-images.githubusercontent.com/1220911/34144440-2794f494-e4c4-11e7-9023-8698b889e31c.png">
