### PR TITLE
Add interface to add new space member

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,16 @@ ribose space remove --space-id 123456789 --confirmation 123456789
 ribose member list --space-id space_uuid
 ```
 
+#### Add a new space member
+
+```sh
+ribose member add \
+  --space-id space_uuid \
+  --user-id=user-one-uuid:role_one_id user-two-uuid:role_two_id \
+  --email=email-one@example.com:role_one_id email@example.com:role_two_id \
+  --message="Your invitation messages to the invitees"
+```
+
 ### Note
 
 #### Listing space notes

--- a/lib/ribose/cli/commands/member.rb
+++ b/lib/ribose/cli/commands/member.rb
@@ -4,13 +4,36 @@ module Ribose
       class Member < Commands::Base
         desc "list", "List space members"
         option :format, aliases: "-f", desc: "Output format, eg: json"
-        option :space_id, required: true, alias: "-s", desc: "The Space UUID"
+        option :space_id, required: true, aliases: "-s", desc: "The Space UUID"
 
         def list
           say(build_output(Ribose::Member.all(options[:space_id]), options))
         end
 
+        desc "add", "Add a new space member"
+        option :space_id, required: true, aliases: "-s", desc: "The Space UUID"
+        option :user_id, aliases: "-u", type: :hash, desc: "Invitee's IDS"
+        option :email, aliases: "-e", type: :hash, desc: "Invitee's emails"
+        option :message, aliases: "-m", desc: "Space invitation message"
+
+        def add
+          add_member_to_space(options)
+          say("Invitation has been sent successfully!")
+        rescue Ribose::UnprocessableEntity
+          say("Something went wrong! Please check required attributes")
+        end
+
         private
+
+        def add_member_to_space(attributes)
+          Ribose::SpaceInvitation.mass_create(
+            attributes[:space_id],
+            body: attributes[:message] || "",
+            emails: (attributes[:email] || {}).keys,
+            user_ids: (attributes[:user_id] || {}).keys,
+            role_ids: (attributes[:email] || {}).merge(attributes[:user_id]),
+          )
+        end
 
         def table_headers
           ["ID", "Name", "Role Name"]

--- a/spec/acceptance/member_spec.rb
+++ b/spec/acceptance/member_spec.rb
@@ -12,4 +12,54 @@ RSpec.describe "Space Member" do
       expect(output).to match(/8332-fcdaecb13e34 | John Doe | Administrator/)
     end
   end
+
+  describe "add" do
+    it "adds a new member to a space" do
+      command = %W(
+        member add
+        --space-id #{invitation.space_id}
+        --user-id #{invitation.id1}:#{invitation.role}
+        --email #{invitation.email1}:0 #{invitation.email2}:1
+        --message #{invitation.message}
+      )
+
+      stub_ribose_space_invitation_mass_create(
+        invitation.space_id, build_attr_in_stub_format(invitation)
+      )
+
+      output = capture_stdout { Ribose::CLI.start(command) }
+
+      expect(output).to match(/Invitation has been sent successfully!/)
+    end
+  end
+
+  def invitation
+    @invitation ||= OpenStruct.new(
+      id1: "123456",
+      id2: "567890",
+      role: "123456",
+      space_id: "123456789",
+      email1: "invitee-one@example.com",
+      email2: "invitee-two@example.com",
+      message: "Your invitation message",
+    )
+  end
+
+  # This might look compact, but the only purpose for this is to prepare
+  # the attributes / sequence with the one webmock would be epxecting to
+  # stub the api request successfully.
+  #
+  def build_attr_in_stub_format(invitation)
+    {
+      body: invitation.message,
+      emails: [invitation.email1, invitation.email2],
+      user_ids: [invitation.id1],
+      role_ids: {
+        "#{invitation.email1}": "0",
+        "#{invitation.email2}": "1",
+        "#{invitation.id1}": invitation.role,
+      },
+      space_id: invitation.space_id,
+    }
+  end
 end


### PR DESCRIPTION
Ribose API offers `Ribose:SpaceInvitation` interface that allows us to invite a user to space, and this commit usages that interface and provides a CLI interface for that. The normal use case is a bit different than the usual command, so please feel free to run the `ribose member add --help` if you need any guideline.

```sh
ribose member add \
  --space-id space_uuid \
  --user-id=user-one-uuid:role_one_id user-two-uuid:role_two_id \
  --email=email-one@example.com:role_one_id email@example.com:role_id \
  --message="Your details inviation messages to the invitees"
```

Screenshot:

<img width="462" alt="screenshot 2017-12-19 16 42 06" src="https://user-images.githubusercontent.com/1220911/34150682-a8e69ed2-e4db-11e7-9e88-930b99cb11f6.png">
