### PR TITLE
Add interface to update a member role

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,6 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in ribose-cli.gemspec
 gemspec
+
+# Temporarily use the development version
+gem "ribose", github: "riboseinc/ribose-ruby", ref: "3e1df36"

--- a/lib/ribose/cli/commands/member.rb
+++ b/lib/ribose/cli/commands/member.rb
@@ -23,6 +23,18 @@ module Ribose
           say("Something went wrong! Please check required attributes")
         end
 
+        desc "update", "Update existing member details"
+        option :role_id, required: true, aliases: "-r", desc: "The role id"
+        option :member_id, required: true, aliases: "-m", desc: "Member UUID"
+        option :space_id, required: true, aliases: "-s", desc: "The Space UUID"
+
+        def update
+          update_member_role(options)
+          say("Member has been updated with new role!")
+        rescue Ribose::UnprocessableEntity
+          say("Something went wrong! Please check required attributes")
+        end
+
         private
 
         def add_member_to_space(attributes)
@@ -32,6 +44,12 @@ module Ribose
             emails: (attributes[:email] || {}).keys,
             user_ids: (attributes[:user_id] || {}).keys,
             role_ids: (attributes[:email] || {}).merge(attributes[:user_id]),
+          )
+        end
+
+        def update_member_role(attributes)
+          Ribose::MemberRole.assign(
+            attributes[:space_id], attributes[:member_id], attributes[:role_id]
           )
         end
 

--- a/spec/acceptance/member_spec.rb
+++ b/spec/acceptance/member_spec.rb
@@ -33,6 +33,17 @@ RSpec.describe "Space Member" do
     end
   end
 
+  describe "update" do
+    it "updates an existing member details" do
+      command = %w(member update --role-id 135 --member-id 246 --space-id 1234)
+
+      stub_ribose_member_role_assign(1234, 246, "135")
+      output = capture_stdout { Ribose::CLI.start(command) }
+
+      expect(output).to match(/Member has been updated with new role!/)
+    end
+  end
+
   def invitation
     @invitation ||= OpenStruct.new(
       id1: "123456",


### PR DESCRIPTION
Ribse API offers an interface that allows us to assign a role to an existing member. This commit usage that interface and provide the command line interface for that. Usage

```sh
ribose member update --role-id 135 --member-id 246 --space-id 1234
```