### PR TITLE
Add interface to remove a space member

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,18 @@ ribose member add \
   --message="Your invitation messages to the invitees"
 ```
 
+#### Update an existing member
+
+```sh
+ribose member update --role-id 135 --member-id 246 --space-id 1234
+```
+
+#### Remove a space member
+
+```sh
+ribose member remove --member-id 246 --space-id 1234
+```
+
 ### Note
 
 #### Listing space notes

--- a/lib/ribose/cli/commands/member.rb
+++ b/lib/ribose/cli/commands/member.rb
@@ -35,6 +35,17 @@ module Ribose
           say("Something went wrong! Please check required attributes")
         end
 
+        desc "remove", "Remove a space member"
+        option :member_id, required: true, aliases: "-m", desc: "Member UUID"
+        option :space_id, required: true, aliases: "-s", desc: "The Space UUID"
+
+        def remove
+          Ribose::Member.delete(options[:space_id], options[:member_id])
+          say("The member has been removed from this space")
+        rescue Ribose::UnprocessableEntity
+          say("Something went wrong! Please provide a valid id/uuid")
+        end
+
         private
 
         def add_member_to_space(attributes)

--- a/spec/acceptance/member_spec.rb
+++ b/spec/acceptance/member_spec.rb
@@ -44,6 +44,17 @@ RSpec.describe "Space Member" do
     end
   end
 
+  describe "remove" do
+    it "removes an existing space member" do
+      command = %w(member remove --member-id 246 --space-id 1234)
+
+      stub_ribose_space_member_delete_api(1234, 246)
+      output = capture_stdout { Ribose::CLI.start(command) }
+
+      expect(output).to match(/The member has been removed from this space/)
+    end
+  end
+
   def invitation
     @invitation ||= OpenStruct.new(
       id1: "123456",


### PR DESCRIPTION
This commit usages the `Ribose::Member.delete` interface and adds a command line interface to remove a member from any specific user space. Usage:

```sh
ribose member remove --member-id 246 --space-id 1234
```