### PR TITLE
Add interface to list space invitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,15 @@ ribose member update --role-id 135 --member-id 246 --space-id 1234
 ribose member remove --member-id 246 --space-id 1234
 ```
 
+### Space Invitation
+
+#### List Space Invitation
+
+```sh
+
+ribose invitation list --space-id 1234 [--query=key:value]
+```
+
 ### Note
 
 #### Listing space notes

--- a/lib/ribose/cli/command.rb
+++ b/lib/ribose/cli/command.rb
@@ -6,6 +6,7 @@ require "ribose/cli/commands/conversation"
 require "ribose/cli/commands/message"
 require "ribose/cli/commands/note"
 require "ribose/cli/commands/member"
+require "ribose/cli/commands/invitation"
 
 module Ribose
   module CLI
@@ -27,6 +28,9 @@ module Ribose
 
       desc "message", "List, Add or Remove Message"
       subcommand :message, Ribose::CLI::Commands::Message
+
+      desc "invitation", "Manage Space Invitations"
+      subcommand :invitation, Ribose::CLI::Commands::Invitation
 
       desc "config", "Configure API Key and User Email"
       option :token, required: true, desc: "Your API Token for Ribose"

--- a/lib/ribose/cli/commands/invitation.rb
+++ b/lib/ribose/cli/commands/invitation.rb
@@ -1,0 +1,28 @@
+module Ribose
+  module CLI
+    module Commands
+      class Invitation < Commands::Base
+        desc "list", "List space invitations"
+        option :space_id, aliases: "-s", desc: "The Space UUID"
+        option :query, type: :hash, desc: "Query parameters as hash"
+        option :format, aliases: "-f", desc: "Output format, eg: json"
+
+        def list
+          say(build_output(Ribose::SpaceInvitation.all(options), options))
+        end
+
+        private
+
+        def table_headers
+          ["ID", "Inviter", "Type", "Space Name"]
+        end
+
+        def table_rows(invitations)
+          invitations.map do |invt|
+            [invt.id, invt.inviter.name, invt.type, invt.space.name]
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/acceptance/invitation_spec.rb
+++ b/spec/acceptance/invitation_spec.rb
@@ -1,0 +1,15 @@
+require "spec_helper"
+
+RSpec.describe "Space Invitation" do
+  describe "list" do
+    it "retrieves the list of space invitations" do
+      command = %w(invitation list --space-id 1234)
+
+      stub_ribose_space_invitation_lis_api
+      output = capture_stdout { Ribose::CLI.start(command) }
+
+      expect(output).to match(/ID    | Inviter    | Type/)
+      expect(output).to match(/Doe | Invitation::ToSpace | The CLI Space/)
+    end
+  end
+end


### PR DESCRIPTION
Ribose API offers `Ribose::SpaceInvitation`, which allows us to retrieve the list of space invitation for the current user, and this commit adds the command line interface for that. By default it will list the details in tabular format, but we can customize it using the `format` option.

This interface also supports `query` option, which we can use to pass customer query parameters as `key:value` pair.

```sh
ribose invitation list --space-id 1234 [--query=key:value]
```