### PR TITLE
Add interface to send a space invitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,9 +126,19 @@ ribose member remove --member-id 246 --space-id 1234
 #### List Space Invitation
 
 ```sh
-
-ribose invitation list --space-id 1234 [--query=key:value]
+ribose invitation list [--query=key:value]
 ```
+
+#### Send out space invitation
+
+```sh
+ribose invitation add \
+  --space-id space_uuid \
+  --user-id=user-one-uuid:role_one_id user-two-uuid:role_two_id \
+  --email=email-one@example.com:role_one_id email@example.com:role_two_id \
+  --message="Your invitation messages to the invitees"
+```
+
 
 ### Note
 

--- a/lib/ribose/cli/commands/invitation.rb
+++ b/lib/ribose/cli/commands/invitation.rb
@@ -3,12 +3,21 @@ module Ribose
     module Commands
       class Invitation < Commands::Base
         desc "list", "List space invitations"
-        option :space_id, aliases: "-s", desc: "The Space UUID"
         option :query, type: :hash, desc: "Query parameters as hash"
         option :format, aliases: "-f", desc: "Output format, eg: json"
 
         def list
           say(build_output(Ribose::SpaceInvitation.all(options), options))
+        end
+
+        desc "add", "Add a new space member"
+        option :space_id, required: true, aliases: "-s", desc: "The Space UUID"
+        option :user_id, aliases: "-u", type: :hash, desc: "Invitee's IDS"
+        option :email, aliases: "-e", type: :hash, desc: "Invitee's emails"
+        option :message, aliases: "-m", desc: "Space invitation message"
+
+        def add
+          invoke(Member, :add)
         end
 
         private

--- a/lib/ribose/cli/commands/member.rb
+++ b/lib/ribose/cli/commands/member.rb
@@ -54,7 +54,9 @@ module Ribose
             body: attributes[:message] || "",
             emails: (attributes[:email] || {}).keys,
             user_ids: (attributes[:user_id] || {}).keys,
-            role_ids: (attributes[:email] || {}).merge(attributes[:user_id]),
+            role_ids: (attributes[:email] || {}).merge(
+              attributes[:user_id] || {},
+            ),
           )
         end
 

--- a/spec/acceptance/invitation_spec.rb
+++ b/spec/acceptance/invitation_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 RSpec.describe "Space Invitation" do
   describe "list" do
     it "retrieves the list of space invitations" do
-      command = %w(invitation list --space-id 1234)
+      command = %w(invitation list)
 
       stub_ribose_space_invitation_lis_api
       output = capture_stdout { Ribose::CLI.start(command) }
@@ -11,5 +11,55 @@ RSpec.describe "Space Invitation" do
       expect(output).to match(/ID    | Inviter    | Type/)
       expect(output).to match(/Doe | Invitation::ToSpace | The CLI Space/)
     end
+  end
+
+  describe "add" do
+    it "sends a space invitation to a member" do
+      command = %W(
+        invitation add
+        --space-id #{invitation.space_id}
+        --user-id #{invitation.id1}:#{invitation.role}
+        --email #{invitation.email1}:0 #{invitation.email2}:1
+        --message #{invitation.message}
+      )
+
+      stub_ribose_space_invitation_mass_create(
+        invitation.space_id, build_attr_in_stub_format(invitation)
+      )
+
+      output = capture_stdout { Ribose::CLI.start(command) }
+
+      expect(output).to match(/Invitation has been sent successfully!/)
+    end
+  end
+
+  def invitation
+    @invitation ||= OpenStruct.new(
+      id1: "123456",
+      id2: "567890",
+      role: "123456",
+      space_id: "123456789",
+      email1: "invitee-one@example.com",
+      email2: "invitee-two@example.com",
+      message: "Your invitation message",
+    )
+  end
+
+  # This might look compact, but the only purpose for this is to prepare
+  # the attributes / sequence with the one webmock would be epxecting to
+  # stub the api request successfully.
+  #
+  def build_attr_in_stub_format(invitation)
+    {
+      body: invitation.message,
+      emails: [invitation.email1, invitation.email2],
+      user_ids: [invitation.id1],
+      role_ids: {
+        "#{invitation.email1}": "0",
+        "#{invitation.email2}": "1",
+        "#{invitation.id1}": invitation.role,
+      },
+      space_id: invitation.space_id,
+    }
   end
 end


### PR DESCRIPTION
This commit adds a command line interface that allows us to send out space invitation to a member. In the underneath, it invokes the `member add` interface to handle the request successfully.

```sh
ribose invitation add \
  --space-id space_uuid \
  --user-id=user-one-uuid:role_one_id user-two-uuid:role_two_id \
  --email=email-one@example.com:role_one_id email@example.com:role_id \
  --message="Your invitation messages to the invitees"
```