### PR TITLE
Add interface to accept a space invitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,11 @@ ribose invitation add \
   --message="Your invitation messages to the invitees"
 ```
 
+#### Accept a space invitation
+
+```sh
+ribose invitation accept --invitation-id 2468
+```
 
 ### Note
 

--- a/lib/ribose/cli/commands/invitation.rb
+++ b/lib/ribose/cli/commands/invitation.rb
@@ -20,6 +20,14 @@ module Ribose
           invoke(Member, :add)
         end
 
+        desc "accept", "Accept a space invitation"
+        option :invitation_id, required: true, desc: "Invitation UUID"
+
+        def accept
+          Ribose::SpaceInvitation.accept(options[:invitation_id])
+          say("Space invitation has been accepted!")
+        end
+
         private
 
         def table_headers

--- a/spec/acceptance/invitation_spec.rb
+++ b/spec/acceptance/invitation_spec.rb
@@ -33,6 +33,17 @@ RSpec.describe "Space Invitation" do
     end
   end
 
+  describe "accept" do
+    it "allows us to accept a space invitation" do
+      command = %w(invitation accept --invitation-id 2468)
+
+      stub_ribose_space_invitation_update_api(2468, state: 1)
+      output = capture_stdout { Ribose::CLI.start(command) }
+
+      expect(output).to match(/Space invitation has been accepted!/)
+    end
+  end
+
   def invitation
     @invitation ||= OpenStruct.new(
       id1: "123456",


### PR DESCRIPTION
Ribose API offers a dedicated interface to accept/reject a space invitation, and this commit adds the command line interface that will allow a user to accept a space invitation.

```sh
ribose invitation accept --invitation-id 2468
```