### PR TITLE
Add interface to update a space invitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,12 @@ ribose invitation add \
   --message="Your invitation messages to the invitees"
 ```
 
+#### Update a space invitation
+
+```sh
+ribose invitation update --invitation-id 2468 --role-id 246
+```
+
 #### Accept a space invitation
 
 ```sh

--- a/lib/ribose/cli/commands/invitation.rb
+++ b/lib/ribose/cli/commands/invitation.rb
@@ -20,6 +20,18 @@ module Ribose
           invoke(Member, :add)
         end
 
+        desc "update", "Update a space invitation"
+        option :role_id, aliases: "-r", desc: "The Role ID"
+        option :state, aliases: "-s", desc: "New state for invitation"
+        option :invitation_id, required: true, desc: "Invitation UUID"
+
+        def update
+          update_invitation(options)
+          say("Space invitation has been updated!")
+        rescue Ribose::UnprocessableEntity
+          say("Something went wrong! Please check required attributes")
+        end
+
         desc "accept", "Accept a space invitation"
         option :invitation_id, required: true, desc: "Invitation UUID"
 
@@ -29,6 +41,12 @@ module Ribose
         end
 
         private
+
+        def update_invitation(attributes)
+          Ribose::SpaceInvitation.update(
+            attributes.delete(:invitation_id), attributes
+          )
+        end
 
         def table_headers
           ["ID", "Inviter", "Type", "Space Name"]

--- a/spec/acceptance/invitation_spec.rb
+++ b/spec/acceptance/invitation_spec.rb
@@ -33,6 +33,17 @@ RSpec.describe "Space Invitation" do
     end
   end
 
+  describe "update" do
+    it "updates the details for an invitation" do
+      command = %w(invitation update --invitation-id 2468 --role-id 246)
+      stub_ribose_space_invitation_update_api(2468, role_id: "246")
+
+      output = capture_stdout { Ribose::CLI.start(command) }
+
+      expect(output).to match(/Space invitation has been updated!/)
+    end
+  end
+
   describe "accept" do
     it "allows us to accept a space invitation" do
       command = %w(invitation accept --invitation-id 2468)


### PR DESCRIPTION
This commit usages the `Ribose::SpaceInvitation.update` interface and provides a command line command for that. Currently the update interface only supports to update a `role_id` or `state` but this can be extended by adding some option to this interface.

```sh
ribose invitation update --invitation-id 2468 --role-id 246
```