### PR TITLE
Add interface to remove an invitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,12 @@ ribose invitation update --invitation-id 2468 --role-id 246
 ribose invitation accept --invitation-id 2468
 ```
 
+#### Remove a space invitation
+
+```sh
+ribose invitation remove --invitation-id 2468
+```
+
 ### Note
 
 #### Listing space notes

--- a/lib/ribose/cli/commands/invitation.rb
+++ b/lib/ribose/cli/commands/invitation.rb
@@ -40,6 +40,16 @@ module Ribose
           say("Space invitation has been accepted!")
         end
 
+        desc "remove", "Remove a space invitation"
+        option :invitation_id, required: true, desc: "Invitation UUID"
+
+        def remove
+          Ribose::SpaceInvitation.cancel(options[:invitation_id])
+          say("Space invitation has been removed!")
+        rescue Ribose::Forbidden
+          say("Could not remove the specified invitation")
+        end
+
         private
 
         def update_invitation(attributes)

--- a/spec/acceptance/invitation_spec.rb
+++ b/spec/acceptance/invitation_spec.rb
@@ -55,6 +55,17 @@ RSpec.describe "Space Invitation" do
     end
   end
 
+  describe "remove" do
+    it "removes a space invitation" do
+      command = %w(invitation remove --invitation-id 2468)
+
+      stub_ribose_space_invitation_cancel_api(2468)
+      output = capture_stdout { Ribose::CLI.start(command) }
+
+      expect(output).to match(/Space invitation has been removed!/)
+    end
+  end
+
   def invitation
     @invitation ||= OpenStruct.new(
       id1: "123456",


### PR DESCRIPTION
The Ribose API offers an endpoint to cancel/remove a space invitation and this commit usages that endpoint and provide a CLI interface for that functionality. Usage

```sh
ribose invitation remove --invitation-id 246
```