### PR TITLE
Add interface to reject a space invitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,12 @@ ribose invitation update --invitation-id 2468 --role-id 246
 ribose invitation accept --invitation-id 2468
 ```
 
+#### Reject a space invitation
+
+```sh
+ribose invitation reject --invitation-id 2468
+```
+
 #### Remove a space invitation
 
 ```sh

--- a/lib/ribose/cli/commands/invitation.rb
+++ b/lib/ribose/cli/commands/invitation.rb
@@ -40,6 +40,14 @@ module Ribose
           say("Space invitation has been accepted!")
         end
 
+        desc "reject", "Reject a space invitation"
+        option :invitation_id, required: true, desc: "Invitation UUID"
+
+        def reject
+          Ribose::SpaceInvitation.reject(options[:invitation_id])
+          say("Space invitation has been rejected!")
+        end
+
         desc "remove", "Remove a space invitation"
         option :invitation_id, required: true, desc: "Invitation UUID"
 

--- a/spec/acceptance/invitation_spec.rb
+++ b/spec/acceptance/invitation_spec.rb
@@ -55,6 +55,17 @@ RSpec.describe "Space Invitation" do
     end
   end
 
+  describe "reject" do
+    it "allows us to reject a space invitation" do
+      command = %w(invitation reject --invitation-id 2468)
+
+      stub_ribose_space_invitation_update_api(2468, state: 2)
+      output = capture_stdout { Ribose::CLI.start(command) }
+
+      expect(output).to match(/Space invitation has been rejected!/)
+    end
+  end
+
   describe "remove" do
     it "removes a space invitation" do
       command = %w(invitation remove --invitation-id 2468)


### PR DESCRIPTION
Previously, we added the `accept` interface that allows a user to accept a space invitation and this commit adds another interface which will allow a user to `reject` an invitation.

```sh
ribose invitation reject --invitation-id 2468
```