### PR TITLE
Add interface to list join space requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,14 @@ ribose invitation reject --invitation-id 2468
 ribose invitation remove --invitation-id 2468
 ```
 
+### Join Space Request
+
+#### List join space requests
+
+```sh
+ribose join-space list [--query=space-id:2468]
+```
+
 ### Note
 
 #### Listing space notes

--- a/lib/ribose/cli/command.rb
+++ b/lib/ribose/cli/command.rb
@@ -7,6 +7,7 @@ require "ribose/cli/commands/message"
 require "ribose/cli/commands/note"
 require "ribose/cli/commands/member"
 require "ribose/cli/commands/invitation"
+require "ribose/cli/commands/join_space"
 
 module Ribose
   module CLI
@@ -31,6 +32,9 @@ module Ribose
 
       desc "invitation", "Manage Space Invitations"
       subcommand :invitation, Ribose::CLI::Commands::Invitation
+
+      desc "join-space", "Manage Join Space Request"
+      subcommand :join_space, Ribose::CLI::Commands::JoinSpace
 
       desc "config", "Configure API Key and User Email"
       option :token, required: true, desc: "Your API Token for Ribose"

--- a/lib/ribose/cli/commands/join_space.rb
+++ b/lib/ribose/cli/commands/join_space.rb
@@ -1,0 +1,27 @@
+module Ribose
+  module CLI
+    module Commands
+      class JoinSpace < Commands::Base
+        desc "list", "List join space requests"
+        option :query, type: :hash, desc: "Query parameters as hash"
+        option :format, aliases: "-f", desc: "Output format, eg: json"
+
+        def list
+          say(build_output(Ribose::JoinSpaceRequest.all(options), options))
+        end
+
+        private
+
+        def table_headers
+          ["ID", "Inviter", "Type", "Space Name"]
+        end
+
+        def table_rows(requests)
+          requests.map do |req|
+            [req.id, req.inviter.name, req.type, req.space.name]
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/acceptance/join_space_spec.rb
+++ b/spec/acceptance/join_space_spec.rb
@@ -1,0 +1,15 @@
+require "spec_helper"
+
+RSpec.describe "Join Space Request" do
+  describe "list" do
+    it "retrieves the list of join space requests" do
+      command = %w(join-space list)
+
+      stub_ribose_join_space_request_list_api
+      output = capture_stdout { Ribose::CLI.start(command) }
+
+      expect(output).to match(/| ID    | Inviter    | Type/)
+      expect(output).to match(/| 27743 | Jennie Doe | Invitation::ToSpace/)
+    end
+  end
+end


### PR DESCRIPTION
This commit adds a CLI interface to list the join space requests, by default it will list some basic attributes in the tabular format. But if we need all the attributes then we pass `json` to  `--format` and it will list all attributes as JSON.

This interface also support one additional hash arguments `query`, which allows us to pass any attributes that will be passed along as a query parameters.

```sh
ribose join-space list [--query=space-id:2468]
```