### PR TITLE
Add interface to add join space request

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,12 @@ ribose invitation remove --invitation-id 2468
 ribose join-space list [--query=space-id:2468]
 ```
 
+#### Add join space request
+
+```sh
+ribose join-space add --space-id 1234 [--message "My request message"]
+```
+
 ### Note
 
 #### Listing space notes

--- a/lib/ribose/cli/commands/join_space.rb
+++ b/lib/ribose/cli/commands/join_space.rb
@@ -10,7 +10,29 @@ module Ribose
           say(build_output(Ribose::JoinSpaceRequest.all(options), options))
         end
 
+        desc "add", "Create a join space request"
+        option :type, aliases: "-t", desc: "The join request type"
+        option :state, desc: "The state for the join space request"
+        option :message, aliases: "-m", desc: "The join request message"
+        option :space_id, required: true, aliases: "-s", desc: "The Space UUID"
+
+        def add
+          create_join_request(options)
+          say("Join space request has been sent successfully!")
+        rescue Ribose::UnprocessableEntity
+          say("Something went wrong! Please check required attributes")
+        end
+
         private
+
+        def create_join_request(attributes)
+          Ribose::JoinSpaceRequest.create(
+            state: attributes[:state] || 0,
+            space_id: attributes[:space_id],
+            body: attributes[:message] || "",
+            type: attributes[:type] || "Invitation::JoinSpaceRequest",
+          )
+        end
 
         def table_headers
           ["ID", "Inviter", "Type", "Space Name"]

--- a/spec/acceptance/join_space_spec.rb
+++ b/spec/acceptance/join_space_spec.rb
@@ -12,4 +12,27 @@ RSpec.describe "Join Space Request" do
       expect(output).to match(/| 27743 | Jennie Doe | Invitation::ToSpace/)
     end
   end
+
+  describe "add" do
+    it "creates a new join space request" do
+      command = %w(join-space add --space-id 1234)
+
+      stub_join_space_request_api_call(1234)
+      output = capture_stdout { Ribose::CLI.start(command) }
+
+      expect(output).to match(/Join space request has been sent successfully!/)
+    end
+  end
+
+  # This prepares the request body to match with wbmock's expected
+  # one to successfully stub  `POST /invitations/join_space_request`
+  #
+  def stub_join_space_request_api_call(space_id, state: 0, body: "")
+    stub_ribose_join_space_request_create_api(
+      state: state,
+      body: body,
+      type: "Invitation::JoinSpaceRequest",
+      space_id: space_id.to_s,
+    )
+  end
 end


### PR DESCRIPTION
This commit adds an interface to create a new join space request. The `space_id` is the required parameter for this interface, but this also support additional option for `type`, `state` and the `message`. If none of the optional parameters are provided then it also sets some standard default for this interface.

```sh
ribose join-space add --space-id 1234 [--message "My request message"]
```