### PR TITLE
Add interface to accept join space request

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,12 @@ ribose join-space list [--query=space-id:2468]
 ribose join-space add --space-id 1234 [--message "My request message"]
 ```
 
+#### Accept a join space request
+
+```sh
+ribose join-space accept --request-id 2468
+```
+
 ### Note
 
 #### Listing space notes

--- a/lib/ribose/cli/commands/join_space.rb
+++ b/lib/ribose/cli/commands/join_space.rb
@@ -23,6 +23,14 @@ module Ribose
           say("Something went wrong! Please check required attributes")
         end
 
+        desc "accept", "Accept a join space request"
+        option :request_id, required: true, aliases: "-r", desc: "Request UUID"
+
+        def accept
+          Ribose::JoinSpaceRequest.accept(options[:request_id])
+          say("Join space request has been accepted!")
+        end
+
         private
 
         def create_join_request(attributes)

--- a/spec/acceptance/join_space_spec.rb
+++ b/spec/acceptance/join_space_spec.rb
@@ -24,6 +24,17 @@ RSpec.describe "Join Space Request" do
     end
   end
 
+  describe "accept" do
+    it "allows a user to accept a join space request" do
+      command = %w(join-space accept --request-id 2468)
+
+      stub_ribose_join_space_request_update(2468, state: 1)
+      output = capture_stdout { Ribose::CLI.start(command) }
+
+      expect(output).to match(/Join space request has been accepted!/)
+    end
+  end
+
   # This prepares the request body to match with wbmock's expected
   # one to successfully stub  `POST /invitations/join_space_request`
   #


### PR DESCRIPTION
Once a user received an join request then they can decide to accept or reject the request, and if the user desire to accept the request then they can use this interface. Usage:

```sh
ribose join-space accept --request-id 2468
```