### PR TITLE
Add interface to reject join space request

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,12 @@ ribose join-space add --space-id 1234 [--message "My request message"]
 ribose join-space accept --request-id 2468
 ```
 
+#### Reject a join space requests
+
+```sh
+ribose join-space reject --request-id 2468
+```
+
 ### Note
 
 #### Listing space notes

--- a/lib/ribose/cli/commands/join_space.rb
+++ b/lib/ribose/cli/commands/join_space.rb
@@ -31,6 +31,14 @@ module Ribose
           say("Join space request has been accepted!")
         end
 
+        desc "reject", "Reject a join space request"
+        option :request_id, required: true, aliases: "-r", desc: "Request UUID"
+
+        def reject
+          Ribose::JoinSpaceRequest.reject(options[:request_id])
+          say("Join space request has been rejected!")
+        end
+
         private
 
         def create_join_request(attributes)

--- a/spec/acceptance/join_space_spec.rb
+++ b/spec/acceptance/join_space_spec.rb
@@ -35,6 +35,17 @@ RSpec.describe "Join Space Request" do
     end
   end
 
+  describe "reject" do
+    it "allows a user to reject a join space request" do
+      command = %w(join-space reject --request-id 2468)
+
+      stub_ribose_join_space_request_update(2468, state: 2)
+      output = capture_stdout { Ribose::CLI.start(command) }
+
+      expect(output).to match(/Join space request has been rejected!/)
+    end
+  end
+
   # This prepares the request body to match with wbmock's expected
   # one to successfully stub  `POST /invitations/join_space_request`
   #


### PR DESCRIPTION
Previously, we've added an interface to accept a join space request, and this commit adds another interface that will allow a user if they decide to reject a space invitation.

```sh
ribose join-space reject --request-id 2468
```