### PR TITLE
Add show interface for join space

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,4 @@ source "https://rubygems.org"
 gemspec
 
 # Temporarily use the development version
-gem "ribose", github: "riboseinc/ribose-ruby", ref: "3e1df36"
+gem "ribose", github: "riboseinc/ribose-ruby", ref: "9b7f256"

--- a/README.md
+++ b/README.md
@@ -171,6 +171,12 @@ ribose invitation remove --invitation-id 2468
 ribose join-space list [--query=space-id:2468]
 ```
 
+#### Fetch a join space request
+
+```sh
+ribose join-space show --request-id 2468
+```
+
 #### Add join space request
 
 ```sh

--- a/lib/ribose/cli/commands/join_space.rb
+++ b/lib/ribose/cli/commands/join_space.rb
@@ -10,6 +10,15 @@ module Ribose
           say(build_output(Ribose::JoinSpaceRequest.all(options), options))
         end
 
+        desc "show", "Fetch a join space request"
+        option :format, aliases: "-f", desc: "Output format, eg: json"
+        option :request_id, required: true, aliases: "-r", desc: "Request UUID"
+
+        def show
+          join_space = Ribose::JoinSpaceRequest.fetch(options[:request_id])
+          say(build_resource_output(join_space, options))
+        end
+
         desc "add", "Create a join space request"
         option :type, aliases: "-t", desc: "The join request type"
         option :state, desc: "The state for the join space request"
@@ -52,6 +61,10 @@ module Ribose
 
         def table_headers
           ["ID", "Inviter", "Type", "Space Name"]
+        end
+
+        def table_field_names
+          %w(id email body state type)
         end
 
         def table_rows(requests)

--- a/spec/acceptance/join_space_spec.rb
+++ b/spec/acceptance/join_space_spec.rb
@@ -13,6 +13,19 @@ RSpec.describe "Join Space Request" do
     end
   end
 
+  describe "show" do
+    it "retrieves the details for a join reqeust" do
+      command = %w(join-space show --request-id 2468)
+
+      stub_ribose_join_space_request_fetch_api(2468)
+      output = capture_stdout { Ribose::CLI.start(command) }
+
+      expect(output).to match(/state | 0/)
+      expect(output).to match(/id    | 123456789/)
+      expect(output).to match(/type  | Invitation::ToSpace/)
+    end
+  end
+
   describe "add" do
     it "creates a new join space request" do
       command = %w(join-space add --space-id 1234)


### PR DESCRIPTION
This commit adds the `show` interface for the `join-space` command, and it also expects a user to provide the `request-id` as required option. By default it will show some basic attributes in a tabular format but we can customize it using the `--format` option.

```sh
ribose join-space show --request-id 2468
```