### PR TITLE
Add interface to fetch file details

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,4 @@ source "https://rubygems.org"
 gemspec
 
 # Temporarily use the development version
-gem "ribose", github: "riboseinc/ribose-ruby", ref: "9b7f256"
+gem "ribose", github: "riboseinc/ribose-ruby", ref: "9d54b48"

--- a/README.md
+++ b/README.md
@@ -241,6 +241,12 @@ ribose file list --space-id 123456
 The above interface will retrieve the basic details in tabular format, but it
 also support additional `format` option, acceptable option: `json`.
 
+#### Fetch a file details
+
+```sh
+ribose file show --file-id 5678 --space-id 1234 [--format json]
+```
+
 #### Add a new file
 
 Ribose CLI allows us to upload a file in a user space, and to upload a new file

--- a/lib/ribose/cli/commands/file.rb
+++ b/lib/ribose/cli/commands/file.rb
@@ -10,6 +10,16 @@ module Ribose
           say(build_output(list_files(options), options))
         end
 
+        desc "show", "Details for a space file"
+        option :file_id, required: true, desc: "The space file ID"
+        option :format, aliases: "-f", desc: "Output format, eg: json"
+        option :space_id, required: true, aliases: "-s", desc: "The Space UUID"
+
+        def show
+          file = Ribose::SpaceFile.fetch(options[:space_id], options[:file_id])
+          say(build_resource_output(file, options))
+        end
+
         desc "add", "Adding a new fille to a space"
         option :space_id, required: true, aliases: "-s", desc: "The Space UUID"
         option :description, aliases: "-d", desc: "The file upload description"
@@ -40,6 +50,10 @@ module Ribose
 
         def table_headers
           ["ID", "Name", "Versions"]
+        end
+
+        def table_field_names
+          %w(id name author content_type content_size version)
         end
 
         def table_rows(files)

--- a/spec/acceptance/file_spec.rb
+++ b/spec/acceptance/file_spec.rb
@@ -13,6 +13,19 @@ RSpec.describe "File Interface" do
     end
   end
 
+  describe "show" do
+    it "retrieves the details for a file" do
+      command = %w(file show --file-id 5678 --space-id 1234)
+
+      stub_ribose_space_file_fetch_api(1234, 5678)
+      output = capture_stdout { Ribose::CLI.start(command) }
+
+      expect(output).to match(/id           | 9896/)
+      expect(output).to match(/name         | sample-file.png/)
+      expect(output).to match(/content_type | image\/png/)
+    end
+  end
+
   describe "adding new file" do
     it "uploads the new file to user space" do
       command = %W(file add --space-id 123456 #{file_attributes[:file]})


### PR DESCRIPTION
This commit adds the `show` interface for `file` command. It expect us to provide the `--file-id` and `--space-id` option then it will print out the details in  tabular format. If we need a different output format then we can use the `--format` option for that.

```sh
ribose file show --file-id 5678 --space-id 1234 [--format json]
```