### PR TITLE
Add interface to remove a space file

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,12 @@ we can use the following interface.
 ribose file add full_path_the_file.ext  --space-id space_uuid **other_options
 ```
 
+#### Remove a space file
+
+```sh
+ribose file remove --file-id 5678 --space-id 1234
+```
+
 ### Conversations
 
 #### Listing conversations

--- a/lib/ribose/cli/commands/file.rb
+++ b/lib/ribose/cli/commands/file.rb
@@ -33,6 +33,15 @@ module Ribose
           end
         end
 
+        desc "remove", "Remove a space file"
+        option :file_id, required: true, aliases: "-f", desc: "Space file ID"
+        option :space_id, required: true, aliases: "-s", desc: "The Space UUID"
+
+        def remove
+          Ribose::SpaceFile.delete(options[:space_id], options[:file_id])
+          say("The file has been removed from your space!")
+        end
+
         private
 
         def list_files(attributes)

--- a/spec/acceptance/file_spec.rb
+++ b/spec/acceptance/file_spec.rb
@@ -37,6 +37,17 @@ RSpec.describe "File Interface" do
     end
   end
 
+  describe "remove" do
+    it "removes a file from a user space" do
+      command = %w(file remove --file-id 5678 --space-id 1234)
+
+      stub_ribose_space_file_delete_api(1234, 5678)
+      output = capture_stdout { Ribose::CLI.start(command) }
+
+      expect(output).to match(/The file has been removed from your space!/)
+    end
+  end
+
   def file_attributes
     { file: sample_fixture, description: "", tag_list: "" }
   end


### PR DESCRIPTION
This commit usages the `Ribose::SpaceFile.delete` interface and provides a CLI interface to remove a file from a user space. The required options are `--space-id` and `--file-id`.

```sh
ribose file remove --file-id 5678 --space-id 1234
```