### PR TITLE
Add interface to update a space file

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,14 @@ we can use the following interface.
 ribose file add full_path_the_file.ext  --space-id space_uuid **other_options
 ```
 
+#### Update a space file
+
+```sh
+ribose file update [--file-name "new filename"] \
+[--description "New description"] \
+[--tags "tag 1, tag 2, tag 3"] --file-id 5678 --space-id 1234
+```
+
 #### Remove a space file
 
 ```sh

--- a/lib/ribose/cli/commands/file.rb
+++ b/lib/ribose/cli/commands/file.rb
@@ -33,6 +33,20 @@ module Ribose
           end
         end
 
+        desc "update", "Update a space file"
+        option :file_name, aliases: "-n", desc: "New name for the file"
+        option :description, aliases: "-d", desc: "New description for file"
+        option :tags, aliases: "-t", desc: "File tags, separated by commas"
+        option :file_id, required: true, aliases: "-f", desc: "Space file ID"
+        option :space_id, required: true, aliases: "-s", desc: "The Space UUID"
+
+        def update
+          update_file(symbolize_keys(options))
+          say("The file has been updated with new attributes")
+        rescue Ribose::UnprocessableEntity
+          say("Something went wrong! Please check required attributes")
+        end
+
         desc "remove", "Remove a space file"
         option :file_id, required: true, aliases: "-f", desc: "Space file ID"
         option :space_id, required: true, aliases: "-s", desc: "The Space UUID"
@@ -54,6 +68,14 @@ module Ribose
             file: file,
             tag_list: attributes[:tag_list],
             description: attributes[:description],
+          )
+        end
+
+        def update_file(attributes)
+          Ribose::SpaceFile.update(
+            attributes.delete(:space_id),
+            attributes.delete(:file_id),
+            attributes,
           )
         end
 

--- a/spec/acceptance/file_spec.rb
+++ b/spec/acceptance/file_spec.rb
@@ -37,6 +37,24 @@ RSpec.describe "File Interface" do
     end
   end
 
+  describe "update" do
+    it "updates details for a space file" do
+      command = %W(
+        file update
+        --file-id 5678
+        --space-id 1234
+        --tags #{update_attributes[:tags]}
+        --file-name #{update_attributes[:file_name]}
+        --description #{update_attributes[:description]}
+      )
+
+      stub_ribose_space_file_update_api(1234, 5678, update_attributes)
+      output = capture_stdout { Ribose::CLI.start(command) }
+
+      expect(output).to match(/The file has been updated with new attributes/)
+    end
+  end
+
   describe "remove" do
     it "removes a file from a user space" do
       command = %w(file remove --file-id 5678 --space-id 1234)
@@ -50,6 +68,10 @@ RSpec.describe "File Interface" do
 
   def file_attributes
     { file: sample_fixture, description: "", tag_list: "" }
+  end
+
+  def update_attributes
+    { tags: "one, two", file_name: "new name", description: "New description" }
   end
 
   def sample_fixture


### PR DESCRIPTION
This commit usages the `Ribose::SpaceFile.udpate` interface and provides a CLI interface for that. The usages it pretty simple all we need to do is provide the new attributes as bellow.

```sh
ribose file update [--file-name "new filename"] \
[--description "New description"] [--tags "tag 1, tag 2, tag 3"] \
--file-id 5678 --space-id 1234
```