### PR TITLE
Add the fix for file upload issue

### DIFF
--- a/ribose-cli.gemspec
+++ b/ribose-cli.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.executables   = "ribose"
 
   spec.add_dependency "thor", "~> 0.19.4"
-  spec.add_dependency "ribose", ">= 0.3.0"
+  spec.add_dependency "ribose", ">= 0.3.2"
   spec.add_dependency "terminal-table"
 
   spec.add_development_dependency "bundler", "~> 1.14"


### PR DESCRIPTION
Recently, there was a new issue introduced in the `ribose-ruby` gem and that was causing the `file add` command to fails. This commit bump the `ribose` version to the latest fixes and it'll fix the issue for now.

Fixes #60